### PR TITLE
Initial Design commit with todos

### DIFF
--- a/frameless-runtime/Cargo.toml
+++ b/frameless-runtime/Cargo.toml
@@ -19,6 +19,7 @@ sp-block-builder = { git = 'https://github.com/paritytech/substrate', tag = "mon
 sp-core = { git = 'https://github.com/paritytech/substrate', tag = "monthly-2023-02", default_features = false}
 sp-inherents = { git = 'https://github.com/paritytech/substrate', tag = "monthly-2023-02", default_features = false}
 sp-io = { git = 'https://github.com/paritytech/substrate', tag = "monthly-2023-02", default_features = false, features = ["with-tracing"] }
+sp-keystore = { optional = true, git = 'https://github.com/paritytech/substrate', tag = "monthly-2023-02", default_features = false }
 sp-offchain = { git = 'https://github.com/paritytech/substrate', tag = "monthly-2023-02", default_features = false}
 sp-runtime = { git = 'https://github.com/paritytech/substrate', tag = "monthly-2023-02", default_features = false}
 sp-session = { git = 'https://github.com/paritytech/substrate', tag = "monthly-2023-02", default_features = false}
@@ -63,6 +64,7 @@ std = [
 	"sp-consensus-aura/std",
 	"sp-application-crypto/std",
 	"sp-finality-grandpa/std",
+	"sp-keystore",
 
 	"frame-metadata/std"
 ]

--- a/frameless-runtime/src/lib.rs
+++ b/frameless-runtime/src/lib.rs
@@ -230,13 +230,13 @@ impl Runtime {
 		// execute it
 		match ext.0 {
 			Call::Money(tx) => {
-				utxo::MoneyPiece::validate(tx).then_some(()).ok_or(())
+				utxo::MoneyPiece::validate(tx).map_err(|_| ())
 			},
 			Call::Kitties(tx) => {
-				utxo::KittiesPiece::validate(tx).then_some(()).ok_or(())
+				utxo::KittiesPiece::validate(tx).map_err(|_| ())
 			},
 			Call::Existence(tx) => {
-				utxo::ExistencePiece::validate(tx).then_some(()).ok_or(())
+				utxo::ExistencePiece::validate(tx).map_err(|_| ())
 			},
 			Call::Upgrade(new_wasm_code) => {
 				// NOTE: make sure to upgrade your spec-version!

--- a/frameless-runtime/src/lib.rs
+++ b/frameless-runtime/src/lib.rs
@@ -110,7 +110,7 @@ impl Default for GenesisConfig {
 			genesis_utxos: vec![
 				utxo::Utxo {
 					redeemer: ALICE_PUB_KEY_BYTES.into(),
-					data: 100u128.encode(),
+					data: utxo::Money::Currency(100u128).encode(),
 					data_id: <utxo::MoneyPiece as TuxedoPiece>::TYPE_ID
 				}
 			]
@@ -514,7 +514,7 @@ mod tests {
 			// Grab genesis value from storage and assert it is correct
 			let genesis_utxo = utxo::Utxo {
 				redeemer: alice_pub_key.into(),
-				data: 100u128.encode(),
+				data: utxo::Money::Currency(100u128).encode(),
 				data_id: <utxo::MoneyPiece as TuxedoPiece>::TYPE_ID
 			};
 			let encoded_utxo =
@@ -524,26 +524,33 @@ mod tests {
 		})
 	}
 
-	// #[test]
-	// fn utxo_money_test_extracter() {
-	// 	new_test_ext().execute_with(|| {
-	// 		let keystore = KeyStore::new();
-	// 		let alice_pub_key =
-	// 			keystore.sr25519_generate_new(SR25519, Some(ALICE_PHRASE)).unwrap();
+	#[test]
+	fn utxo_money_test_extracter() {
+		new_test_ext().execute_with(|| {
+			let keystore = KeyStore::new();
+			let alice_pub_key =
+				keystore.sr25519_generate_new(SR25519, Some(ALICE_PHRASE)).unwrap();
 
-	// 		let genesis_utxo = utxo::Utxo {
-	// 			redeemer: alice_pub_key.into(),
-	// 			data: 100u128.encode(),
-	// 			data_id: <utxo::MoneyPiece as TuxedoPiece>::TYPE_ID,
-	// 		};
+			let genesis_utxo = utxo::Utxo {
+				redeemer: alice_pub_key.into(),
+				data: utxo::Money::Currency(100u128).encode(),
+				data_id: <utxo::MoneyPiece as TuxedoPiece>::TYPE_ID,
+			};
 
-	// 		let expected_data = 100u128;
-	// 		let extracted_data =
-	// 			utxo::PieceExtracter::<utxo::MoneyPiece>::extract(BlakeTwo256::hash_of(&genesis_utxo))
-	// 			.expect("Can extract Genesis Data");
-	// 		assert_eq!(extracted_data, expected_data);
-	// 	})
-	// }
+			let expected_data = 100u128;
+			let extracted_type =
+				utxo::PieceExtracter::<utxo::MoneyPiece>::extract(BlakeTwo256::hash_of(&genesis_utxo))
+				.expect("Can extract Genesis Data");
+			match extracted_type {
+				utxo::Money::Currency(extracted_value) => {
+					assert_eq!(extracted_value, expected_data);
+				},
+				utxo::Money::Existence(existence) => {
+					// do some assertion in this case
+				},
+			}
+		})
+	}
 
 	// TODO: More Tests for Money Kitties ETC
 

--- a/frameless-runtime/src/lib.rs
+++ b/frameless-runtime/src/lib.rs
@@ -524,26 +524,26 @@ mod tests {
 		})
 	}
 
-	#[test]
-	fn utxo_money_test_extracter() {
-		new_test_ext().execute_with(|| {
-			let keystore = KeyStore::new();
-			let alice_pub_key =
-				keystore.sr25519_generate_new(SR25519, Some(ALICE_PHRASE)).unwrap();
+	// #[test]
+	// fn utxo_money_test_extracter() {
+	// 	new_test_ext().execute_with(|| {
+	// 		let keystore = KeyStore::new();
+	// 		let alice_pub_key =
+	// 			keystore.sr25519_generate_new(SR25519, Some(ALICE_PHRASE)).unwrap();
 
-			let genesis_utxo = utxo::Utxo {
-				redeemer: alice_pub_key.into(),
-				data: 100u128.encode(),
-				data_id: <utxo::MoneyPiece as TuxedoPiece>::TYPE_ID,
-			};
+	// 		let genesis_utxo = utxo::Utxo {
+	// 			redeemer: alice_pub_key.into(),
+	// 			data: 100u128.encode(),
+	// 			data_id: <utxo::MoneyPiece as TuxedoPiece>::TYPE_ID,
+	// 		};
 
-			let expected_data = 100u128;
-			let extracted_data =
-				utxo::PieceExtracter::<utxo::MoneyPiece>::extract(BlakeTwo256::hash_of(&genesis_utxo))
-				.expect("Can extract Genesis Data");
-			assert_eq!(extracted_data, expected_data);
-		})
-	}
+	// 		let expected_data = 100u128;
+	// 		let extracted_data =
+	// 			utxo::PieceExtracter::<utxo::MoneyPiece>::extract(BlakeTwo256::hash_of(&genesis_utxo))
+	// 			.expect("Can extract Genesis Data");
+	// 		assert_eq!(extracted_data, expected_data);
+	// 	})
+	// }
 
 	// TODO: More Tests for Money Kitties ETC
 

--- a/frameless-runtime/src/utxo.rs
+++ b/frameless-runtime/src/utxo.rs
@@ -316,8 +316,8 @@ impl UtxoSet for KittiesPiece {
     /// - Not consuming it but marking it as spent
     ///
     fn nullify(utxo_ref: UtxoRef) -> Option<Utxo> {
-        None
-        // let parents = PieceExtractor::<Self>::extract(utxo_ref).ok_or(())?;
+        // let parents = PieceExtracter::<Self>::extract(utxo_ref)?;
+
         // if Self::mom_ready(&parents.mom) {
 
         // }
@@ -327,6 +327,7 @@ impl UtxoSet for KittiesPiece {
         //     Err(_) => None,
         // }
         // PieceExtractor::<Self>::extract(utxo_ref)
+        None
     }
 }
 

--- a/frameless-runtime/src/utxo.rs
+++ b/frameless-runtime/src/utxo.rs
@@ -159,10 +159,3 @@ impl TuxedoPiece for ExistencePiece {
         true
     }
 }
-
-
-
-
-
-
-

--- a/frameless-runtime/src/utxo.rs
+++ b/frameless-runtime/src/utxo.rs
@@ -200,11 +200,19 @@ impl UtxoSet for MoneyPiece {
 }
 
 pub trait MoneyConfig {
+    type Existence;
+}
+
+impl MoneyConfig for MoneyPiece {
+    type Existence = ExistencePiece;
+}
+
+pub trait MoneyData {
     type Currency: Encode + Decode;
     type Existence: Encode + Decode;
 }
 
-impl MoneyConfig for Money {
+impl MoneyData for Money {
     type Currency = u128;
     type Existence = H256;
 }
@@ -231,8 +239,8 @@ impl TuxedoPiece for MoneyPiece {
         // Always pre-validate before every validate
         PreValidator::<Self>::pre_validate(&transaction)?;
 
-        let mut total_input_value: <Self::Data as MoneyConfig>::Currency = 0;
-        let mut total_output_value: <Self::Data as MoneyConfig>::Currency = 0;
+        let mut total_input_value: <Self::Data as MoneyData>::Currency = 0;
+        let mut total_output_value: <Self::Data as MoneyData>::Currency = 0;
 
         // Check that sum of input values < output values
         for input in transaction.inputs.iter() {
@@ -242,6 +250,7 @@ impl TuxedoPiece for MoneyPiece {
                     total_input_value.checked_add(value).ok_or(())?;
                 },
                 Money::Existence(existence_value) => {
+                    // <<Self as MoneyConfig>::Existence as Verify>::verify_input(&existence_value)
                     // TODO: Could add some helpers such that you can easily access
                     //       The state of an existence piece and its validation logic
                     // Check state of existence Piece? and validate? some glue code?

--- a/frameless-runtime/src/utxo.rs
+++ b/frameless-runtime/src/utxo.rs
@@ -1,0 +1,166 @@
+use parity_scale_codec::{Decode, Encode, MaxEncodedLen};
+use scale_info::TypeInfo;
+#[cfg(feature = "std")]
+use serde::{Deserialize, Serialize};
+use sp_core::{
+	H256,
+	H512,
+	sr25519::{Public, Signature},
+};
+use sp_std::collections::btree_set::BTreeSet;
+use sp_std::prelude::*;
+use sp_runtime::{
+	traits::{BlakeTwo256, Hash},
+	transaction_validity::{TransactionLongevity, ValidTransaction},
+};
+
+use log::info;
+
+///
+/// TODO: Something similar to construct_runtime! which will setup all the configurations for a UTXO runtime
+/// construct_utxo_runtime!(
+///     MoneyUTXO // Configuration for MoneyUTXO
+///     KittiesUTXO // Configuration for KittiesUTXO
+///     ExistenceUTXO // Configuration for ExistenceUTXO
+/// )
+///
+
+// TODO: Configurable maybe when configuring overall UTXO Runtime?
+// For now hardcoded
+pub type OutputRef = H256;
+pub type Address = H256;
+
+/// A single input references the output to be consumed or peeked at and provides some witness data, possibly a signature.
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize, parity_util_mem::MallocSizeOf))]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Default, Clone, Encode, Decode, Hash, Debug, TypeInfo)]
+pub struct Input {
+    /// A previously created output that will be consumed by the transaction containing this input.
+    output: OutputRef,
+    /// A witness proving that the output can be consumed by this input. In many cases including that of a basic cryptocurrency, this will be a digital signature.
+    redeemer: Vec<u8>,
+}
+
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize, parity_util_mem::MallocSizeOf))]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Default, Clone, Encode, Decode, Hash, Debug, TypeInfo)]
+pub struct Output {
+    /// The address that owns this output. Based on either a public key or a Tuxedo Piece
+    pub owner: Address,
+    /// The data associated with this output. In the simplest case, this will be a token balance, but could be arbitrarily rich state.
+    pub data: Vec<u8>,
+}
+
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize, parity_util_mem::MallocSizeOf))]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Default, Clone, Encode, Decode, Hash, Debug, TypeInfo)]
+pub struct Transaction {
+    /// The inputs refer to currently existing unspent outputs that will be consumed by this transaction
+    pub inputs: BTreeSet<Input>,
+    /// Similar to inputs, Peeks refer to currently existing utxos, but they will be read only, and not consumed
+    pub peeks: BTreeSet<Input>,
+    /// The new outputs to be created by this transaction.
+    pub outputs: Vec<Output>,
+}
+
+pub type Utxo = Output;
+pub type UtxoRef = OutputRef;
+
+// TODO: Implement this on Each Tuxedo Piece??
+pub trait UtxoSet {
+    /// Check whether a given utxo exists in the current set
+    fn contains(utxo_ref: UtxoRef) -> bool;
+
+    /// Insert the given utxo into the state storing it with the given ref
+    /// The ref is probably the hash of a tx that created it and its index in that tx, but this decision is opaque to this trait
+    /// Return whether the operation is successful (It can fail if the ref is already present)
+    fn insert(utxo_ref: UtxoRef, utxo: Utxo) -> bool;
+
+    ///
+    /// nullify the utxo by either:
+    /// - Consuming it entirely
+    /// - Putting it on "Timeout"
+    /// - Not consuming it but marking it as spent
+    ///
+    fn nullify(utxo_ref: UtxoRef) -> Option<Utxo>;
+}
+
+// Value to represent a fungible value of a UTXO
+pub type Value = Vec<u8>;
+pub type DispatchResult = Result<(), sp_runtime::DispatchError>;
+
+/// The API of a Tuxedo Piece
+pub trait TuxedoPiece {
+    /// The type of data stored in Outputs associated with this Piece
+    type Data: Encode + Decode;
+
+    /// The validation function to determine whether a given input can be consumed.
+    fn validate(transaction: Transaction) -> bool;
+}
+
+// User defined logic below for the STF..
+
+pub struct MoneyPiece; // Decodes Value -> u128
+impl TuxedoPiece for MoneyPiece {
+    type Data = u128;
+
+    fn validate(transaction: Transaction) -> bool {
+        // decode the transaction output data as type `Data`
+        // TODO: Implement Money situation
+        true
+    }
+}
+
+// Api USER defined
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize, parity_util_mem::MallocSizeOf))]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Default, Clone, Encode, Decode, Hash, Debug, TypeInfo)]
+pub enum DadKittyStatus {
+    #[default]
+    RearinToGo,
+    Tired,
+}
+
+// Api USER defined
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize, parity_util_mem::MallocSizeOf))]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Default, Clone, Encode, Decode, Hash, Debug, TypeInfo)]
+pub enum MomKittyStatus {
+    #[default]
+    RearinToGo,
+    HadBirthRecently,
+}
+
+// Api USER defined
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize, parity_util_mem::MallocSizeOf))]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Default, Clone, Encode, Decode, Hash, Debug, TypeInfo)]
+pub struct KittyData {
+    dad: DadKittyStatus,
+    mom: MomKittyStatus,
+}
+
+pub struct KittiesPiece; // Decodes Value -> KittyData
+impl TuxedoPiece for KittiesPiece {
+    type Data = KittyData; // This is API user Defined
+
+    fn validate(transaction: Transaction) -> bool {
+        // decode transaction output data as type 'Data'
+        // if it fails then return early
+        // TODO: Implement Kitty Logic scenario
+        true
+    }
+}
+
+pub struct ExistencePiece; // Decodes Value -> H256
+impl TuxedoPiece for ExistencePiece {
+    type Data = H256;
+
+    fn validate(transaction: Transaction) -> bool {
+        // decode transaction output data as type 'Data'
+        // if it fails then return early
+        // TODO: Implement Proof of existence Logic scenario
+        true
+    }
+}
+
+
+
+
+
+
+

--- a/frameless-runtime/src/utxo.rs
+++ b/frameless-runtime/src/utxo.rs
@@ -29,6 +29,12 @@ use log::info;
 // For now hardcoded
 pub type OutputRef = H256;
 pub type Address = H256;
+pub type Value = Vec<u8>;
+pub type Sig = Vec<u8>;
+
+// pub type DispatchResult = Result<(), sp_runtime::DispatchError>;
+// Temporary should probably move to something like this above ^^
+pub type DispatchResult = Result<(), ()>;
 
 /// A single input references the output to be consumed or peeked at and provides some witness data, possibly a signature.
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize, parity_util_mem::MallocSizeOf))]
@@ -37,7 +43,7 @@ pub struct Input {
     /// A previously created output that will be consumed by the transaction containing this input.
     output: OutputRef,
     /// A witness proving that the output can be consumed by this input. In many cases including that of a basic cryptocurrency, this will be a digital signature.
-    redeemer: Vec<u8>,
+    redeemer: Sig,
 }
 
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize, parity_util_mem::MallocSizeOf))]
@@ -46,7 +52,7 @@ pub struct Output {
     /// The address that owns this output. Based on either a public key or a Tuxedo Piece
     pub owner: Address,
     /// The data associated with this output. In the simplest case, this will be a token balance, but could be arbitrarily rich state.
-    pub data: Vec<u8>,
+    pub data: Value,
 }
 
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize, parity_util_mem::MallocSizeOf))]
@@ -81,10 +87,6 @@ pub trait UtxoSet {
     ///
     fn nullify(utxo_ref: UtxoRef) -> Option<Utxo>;
 }
-
-// Value to represent a fungible value of a UTXO
-pub type Value = Vec<u8>;
-pub type DispatchResult = Result<(), sp_runtime::DispatchError>;
 
 /// The API of a Tuxedo Piece
 pub trait TuxedoPiece {

--- a/frameless-runtime/src/utxo.rs
+++ b/frameless-runtime/src/utxo.rs
@@ -13,8 +13,11 @@ use sp_runtime::{
 	traits::{BlakeTwo256, Hash},
 	transaction_validity::{TransactionLongevity, ValidTransaction},
 };
+use sp_std::marker::PhantomData;
 
 use log::info;
+
+/// TODO: Clean up this file and organize different parts into different modules for easier reading.
 
 ///
 /// TODO: Something similar to construct_runtime! which will setup all the configurations for a UTXO runtime
@@ -31,6 +34,8 @@ pub type OutputRef = H256;
 pub type Address = H256;
 pub type Value = Vec<u8>;
 pub type Sig = Vec<u8>;
+pub type TypeId = [u8; 4];
+pub type Redeemer = sp_core::H256;
 
 // pub type DispatchResult = Result<(), sp_runtime::DispatchError>;
 // Temporary should probably move to something like this above ^^
@@ -41,27 +46,29 @@ pub type DispatchResult = Result<(), ()>;
 #[derive(PartialEq, Eq, PartialOrd, Ord, Default, Clone, Encode, Decode, Hash, Debug, TypeInfo)]
 pub struct Input {
     /// A previously created output that will be consumed by the transaction containing this input.
-    output: OutputRef,
+    pub output: OutputRef,
     /// A witness proving that the output can be consumed by this input. In many cases including that of a basic cryptocurrency, this will be a digital signature.
-    redeemer: Sig,
+    pub witness: Sig,
 }
 
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize, parity_util_mem::MallocSizeOf))]
 #[derive(PartialEq, Eq, PartialOrd, Ord, Default, Clone, Encode, Decode, Hash, Debug, TypeInfo)]
 pub struct Output {
     /// The address that owns this output. Based on either a public key or a Tuxedo Piece
-    pub owner: Address,
+    pub redeemer: Redeemer,
     /// The data associated with this output. In the simplest case, this will be a token balance, but could be arbitrarily rich state.
     pub data: Value,
+    /// An Id for this type Such that we know how to encode or decode the 'data' field
+    pub data_id: TypeId,
 }
 
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize, parity_util_mem::MallocSizeOf))]
 #[derive(PartialEq, Eq, PartialOrd, Ord, Default, Clone, Encode, Decode, Hash, Debug, TypeInfo)]
 pub struct Transaction {
     /// The inputs refer to currently existing unspent outputs that will be consumed by this transaction
-    pub inputs: BTreeSet<Input>,
+    pub inputs: Vec<Input>,
     /// Similar to inputs, Peeks refer to currently existing utxos, but they will be read only, and not consumed
-    pub peeks: BTreeSet<Input>,
+    pub peeks: Option<Vec<Input>>,
     /// The new outputs to be created by this transaction.
     pub outputs: Vec<Output>,
 }
@@ -69,8 +76,25 @@ pub struct Transaction {
 pub type Utxo = Output;
 pub type UtxoRef = OutputRef;
 
-// TODO: Implement this on Each Tuxedo Piece??
+pub trait Redeem {
+    fn redeem(self, tx: &[u8], witness: &[u8]) -> bool;
+}
+
+impl Redeem for Redeemer {
+    fn redeem(self, tx: &[u8], witness: &[u8]) -> bool {
+        let signature = match Signature::try_from(&witness[..]) {
+            Ok(sig) => sig,
+            Err(_) => return false,
+        };
+        sp_io::crypto::sr25519_verify(&signature, &tx, &Public::from_h256(self))
+    }
+}
+
+// TODO: Implement this for Each Tuxedo Piece
 pub trait UtxoSet {
+
+    /// TODO: Change these bool return types to Result types for more error propagation clarity
+
     /// Check whether a given utxo exists in the current set
     fn contains(utxo_ref: UtxoRef) -> bool;
 
@@ -86,25 +110,91 @@ pub trait UtxoSet {
     /// - Not consuming it but marking it as spent
     ///
     fn nullify(utxo_ref: UtxoRef) -> Option<Utxo>;
+
+    fn peak(utxo_ref: UtxoRef) -> Option<Utxo> {
+        let encoded_utxo = sp_io::storage::get(&utxo_ref.encode())?;
+        match Utxo::decode(&mut &encoded_utxo[..]) {
+            Ok(utxo) => Some(utxo),
+            Err(_) => None,
+        }
+    }
+}
+
+pub trait Get<T> {
+    fn get(&self) -> T;
 }
 
 /// The API of a Tuxedo Piece
 pub trait TuxedoPiece {
     /// The type of data stored in Outputs associated with this Piece
     type Data: Encode + Decode;
+    const TYPE_ID: TypeId;
 
     /// The validation function to determine whether a given input can be consumed.
     fn validate(transaction: Transaction) -> bool;
 }
 
+pub struct PieceExtracter<Piece>(PhantomData<Piece>);
+impl<Piece: TuxedoPiece> PieceExtracter<Piece> {
+    pub fn extract(key: UtxoRef) -> Result<Piece::Data, ()> {
+        let encoded_utxo = sp_io::storage::get(&key.encode()).ok_or(())?;
+        let utxo = Utxo::decode(&mut &encoded_utxo[..]).map_err(|_| ())?;
+        if utxo.data_id != Piece::TYPE_ID {
+            return Err(())
+        }
+        let piece_data = Piece::Data::decode(&mut &utxo.data[..]).map_err(|_| ())?;
+        Ok(piece_data)
+    }
+}
+
 // User defined logic below for the STF..
 
 pub struct MoneyPiece; // Decodes Value -> u128
+impl UtxoSet for MoneyPiece {
+    fn contains(utxo_ref: UtxoRef) -> bool {
+        sp_io::storage::exists(&utxo_ref.encode())
+    }
+
+    fn insert(utxo_ref: UtxoRef, utxo: Utxo) -> bool {
+        sp_io::storage::set(&utxo_ref.encode(), &utxo.encode());
+        true
+    }
+
+    /// For the Money UTXO we just want to consume it.
+    fn nullify(utxo_ref: UtxoRef) -> Option<Utxo> {
+        let encoded_utxo = sp_io::storage::get(&utxo_ref.encode())?;
+        sp_io::storage::clear(&utxo_ref.encode());
+        match Utxo::decode(&mut &encoded_utxo[..]) {
+            Ok(utxo) => Some(utxo),
+            Err(_) => None,
+        }
+    }
+}
+
 impl TuxedoPiece for MoneyPiece {
     type Data = u128;
+    const TYPE_ID: TypeId = *b"1111";
 
     fn validate(transaction: Transaction) -> bool {
-        // decode the transaction output data as type `Data`
+        // Check that the input is unique and a set
+        {
+            let input_set: BTreeSet<_> = transaction.inputs.iter().collect();
+            if input_set.len() < transaction.inputs.len() {
+                return false;
+            }
+        }
+
+        // 1.) Check that the outputs referenced by each input can be redeemed
+        // 2.) Check that sum of input values < output values
+        for input in transaction.inputs.iter() {
+            if let Some(utxo) = <Self as UtxoSet>::peak(input.output) {
+                let _ = utxo.redeemer.redeem(&transaction.encode(), &input.witness);
+                // TODO: check that the redeem passes
+                // Sum up inputs
+            }
+        }
+
+        // if it fails then return early
         // TODO: Implement Money situation
         true
     }
@@ -139,9 +229,10 @@ pub struct KittyData {
 pub struct KittiesPiece; // Decodes Value -> KittyData
 impl TuxedoPiece for KittiesPiece {
     type Data = KittyData; // This is API user Defined
+    const TYPE_ID: TypeId = *b"2222";
 
     fn validate(transaction: Transaction) -> bool {
-        // decode transaction output data as type 'Data'
+        // Check that the input is unique and a set
         // if it fails then return early
         // TODO: Implement Kitty Logic scenario
         true
@@ -151,9 +242,10 @@ impl TuxedoPiece for KittiesPiece {
 pub struct ExistencePiece; // Decodes Value -> H256
 impl TuxedoPiece for ExistencePiece {
     type Data = H256;
+    const TYPE_ID: TypeId = *b"3333";
 
     fn validate(transaction: Transaction) -> bool {
-        // decode transaction output data as type 'Data'
+        // Check that the input is unique and a set
         // if it fails then return early
         // TODO: Implement Proof of existence Logic scenario
         true

--- a/frameless-runtime/src/utxo.rs
+++ b/frameless-runtime/src/utxo.rs
@@ -282,10 +282,73 @@ impl TuxedoPiece for KittiesPiece {
     type Error = ();
 
     fn validate(transaction: Transaction) -> Result<(), Self::Error> {
-        // Check that the input is unique and a set
-        // if it fails then return early
+        PreValidator::<Self>::pre_validate(&transaction)?;
         // TODO: Implement Kitty Logic scenario
+
+        // 1.) If you want to breed Mom cannot have given birth before
+        // 2.) If you want to breed Dad cannot be too tired
+        for input in transaction.inputs.iter() {
+            let parents = PieceExtracter::<Self>::extract(input.output)?;
+            Self::mom_and_dad_ready(&parents)?;
+        }
         Ok(())
+    }
+}
+
+impl UtxoSet for KittiesPiece {
+    /// Check whether a given utxo exists in the current set
+    fn contains(utxo_ref: UtxoRef) -> bool {
+        sp_io::storage::exists(&utxo_ref.encode())
+    }
+
+    /// Insert the given utxo into the state storing it with the given ref
+    /// The ref is probably the hash of a tx that created it and its index in that tx, but this decision is opaque to this trait
+    /// Return whether the operation is successful (It can fail if the ref is already present)
+    fn insert(utxo_ref: UtxoRef, utxo: &Utxo) -> bool {
+        sp_io::storage::set(&utxo_ref.encode(), &utxo.encode());
+        true
+    }
+
+    ///
+    /// nullify the utxo by either:
+    /// - Consuming it entirely
+    /// - Putting it on "Timeout"
+    /// - Not consuming it but marking it as spent
+    ///
+    fn nullify(utxo_ref: UtxoRef) -> Option<Utxo> {
+        None
+        // let parents = PieceExtractor::<Self>::extract(utxo_ref).ok_or(())?;
+        // if Self::mom_ready(&parents.mom) {
+
+        // }
+        // let encoded_utxo = sp_io::storage::get(&utxo_ref.encode())?;
+        // match Utxo::decode(&mut &encoded_utxo[..]) {
+        //     Ok(utxo) => Some(utxo),
+        //     Err(_) => None,
+        // }
+        // PieceExtractor::<Self>::extract(utxo_ref)
+    }
+}
+
+impl KittiesPiece {
+    fn mom_and_dad_ready(parents: &<Self as TuxedoPiece>::Data) -> Result<(), ()> {
+        Self::mom_ready(&parents.mom).then_some(()).ok_or(())?;
+        Self::dad_ready(&parents.dad).then_some(()).ok_or(())?;
+        Ok(())
+    }
+
+    fn mom_ready(mom_status: &MomKittyStatus) -> bool {
+        match mom_status {
+            MomKittyStatus::RearinToGo => true,
+            MomKittyStatus::HadBirthRecently => false,
+        }
+    }
+
+    fn dad_ready(dad_status: &DadKittyStatus) -> bool {
+        match dad_status {
+            DadKittyStatus::RearinToGo => true,
+            DadKittyStatus::Tired => false,
+        }
     }
 }
 


### PR DESCRIPTION
Current check list of Todos (Totally open and willing to change this):
- [x] Initial design structure for different kinds of transactions
- [x] Working flow of different UTXOS
- [x] Implement `TuxedoPiece` trait on each user defined UTXO type
    - [x] implement `fn validate` for MoneyPiece
        - [x] Tests for MoneyPiece
    - [x] implement 'fn validate' for KittiesPiece
        - [ ] Tests for KittiesPiece
    - [ ] implement 'fn validate' for ExistencePiece
        - [ ] Tests for ExistencePiece
- [ ] Implement `UtxoSet` trait on each UTXO type i.e. KittiesPiece, MoneyPiece, etc..  or just on a single `UtxoSet` type?
- [ ] Runtime Tests for overall system
- [ ] Refactor and cleanup all old lingering code which is unecessary
- [ ] Tuxedo version of `construct_runtime!`? So that we can for instance configure the `Call` enum for different TuxedoPieces
- [ ] Integration Test in a multi UTXO Tuxedo Runtime
- [ ] ChainSpec and CLI support for Tuxedo

This most likely will not be a single pr but is more of a brain dump of tasks.
