### PR TITLE
Amoeba tests

### DIFF
--- a/frameless-runtime/src/amoeba.rs
+++ b/frameless-runtime/src/amoeba.rs
@@ -37,7 +37,7 @@ impl UtxoData for AmoebaDetails {
 }
 
 /// Reasons that the amoeba verifiers may fail
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq)]
 pub enum VerifierError {
     // TODO In the current design, this will need to be repeated in every piece. This is not nice.
     // Well, actually, no. Some pieces will be flexible about how many inputs and outputs they can take.
@@ -181,5 +181,26 @@ impl Verifier for AmoebaCreation {
         ensure!(input_data.is_empty(), VerifierError::WrongNumberInputs);
 
         Ok(0)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use tuxedo_core::dynamic_typing::testing::Bogus;
+
+    #[test]
+    fn valid_creation_works() {
+        let to_spawn = AmoebaDetails {
+            generation: 0,
+            four_bytes: *b"test",
+        };
+        let input_data = vec![to_spawn.into()];
+        let output_data = Vec::new();
+
+        assert_eq!(
+            AmoebaCreation.verify(&input_data, &output_data),
+            Ok(0),
+        )
     }
 }

--- a/frameless-runtime/src/amoeba.rs
+++ b/frameless-runtime/src/amoeba.rs
@@ -190,17 +190,47 @@ mod test {
     use tuxedo_core::dynamic_typing::testing::Bogus;
 
     #[test]
-    fn valid_creation_works() {
+    fn creation_valid_transaction_works() {
         let to_spawn = AmoebaDetails {
             generation: 0,
             four_bytes: *b"test",
         };
-        let input_data = vec![to_spawn.into()];
-        let output_data = Vec::new();
+        let input_data = Vec::new();
+        let output_data = vec![to_spawn.into()];
 
         assert_eq!(
             AmoebaCreation.verify(&input_data, &output_data),
             Ok(0),
-        )
+        );
+    }
+
+    #[test]
+    fn creation_invalid_generation_fails() {
+        todo!()
+    }
+
+    #[test]
+    fn creation_with_inputs_fails() {
+        let example = AmoebaDetails {
+            generation: 0,
+            four_bytes: *b"test",
+        };
+        let input_data = vec![example.clone().into()];
+        let output_data = vec![example.into()];
+
+        assert_eq!(
+            AmoebaCreation.verify(&input_data, &output_data),
+            Err(VerifierError::WrongNumberInputs),
+        );
+    }
+
+    #[test]
+    fn creation_with_badly_typed_output_fails() {
+        todo!()
+    }
+
+    #[test]
+    fn creation_multiple_fails() {
+        todo!()
     }
 }

--- a/frameless-runtime/src/amoeba.rs
+++ b/frameless-runtime/src/amoeba.rs
@@ -259,4 +259,157 @@ mod test {
             Err(VerifierError::WrongNumberOutputs),
         );
     }
+
+    #[test]
+    fn mitosis_valid_transaction_works() {
+        let mother = AmoebaDetails {
+            generation: 1,
+            four_bytes: *b"test",
+        };
+        let d1 = AmoebaDetails {
+            generation: 2,
+            four_bytes: *b"test",
+        };
+        let d2 = AmoebaDetails {
+            generation: 2,
+            four_bytes: *b"test",
+        };
+        let input_data = vec![mother.into()];
+        let output_data = vec![d1.into(), d2.into()];
+
+        assert_eq!(
+            AmoebaMitosis.verify(&input_data, &output_data),
+            Ok(0),
+        );
+    }
+
+    #[test]
+    fn mitosis_wrong_generation() {
+        let mother = AmoebaDetails {
+            generation: 1,
+            four_bytes: *b"test",
+        };
+        let d1 = AmoebaDetails {
+            generation: 3, // This daughter has the wrong generation
+            four_bytes: *b"test",
+        };
+        let d2 = AmoebaDetails {
+            generation: 2,
+            four_bytes: *b"test",
+        };
+        let input_data = vec![mother.into()];
+        let output_data = vec![d1.into(), d2.into()];
+
+        assert_eq!(
+            AmoebaMitosis.verify(&input_data, &output_data),
+            Err(VerifierError::WrongGeneration),
+        );
+    }
+
+    #[test]
+    fn mitosis_badly_typed_input() {
+        let mother = Bogus;
+        let d1 = AmoebaDetails {
+            generation: 2,
+            four_bytes: *b"test",
+        };
+        let d2 = AmoebaDetails {
+            generation: 2,
+            four_bytes: *b"test",
+        };
+        let input_data = vec![mother.into()];
+        let output_data = vec![d1.into(), d2.into()];
+
+        assert_eq!(
+            AmoebaMitosis.verify(&input_data, &output_data),
+            Err(VerifierError::BadlyTypedInput),
+        );
+    }
+
+    #[test]
+    fn mitosis_no_input() {
+        let d1 = AmoebaDetails {
+            generation: 2,
+            four_bytes: *b"test",
+        };
+        let d2 = AmoebaDetails {
+            generation: 2,
+            four_bytes: *b"test",
+        };
+        let input_data = Vec::new();
+        let output_data = vec![d1.into(), d2.into()];
+
+        assert_eq!(
+            AmoebaMitosis.verify(&input_data, &output_data),
+            Err(VerifierError::WrongNumberInputs),
+        );
+    }
+
+    #[test]
+    fn mitosis_badly_typed_output() {
+        let mother = AmoebaDetails {
+            generation: 1,
+            four_bytes: *b"test",
+        };
+        let d1 = AmoebaDetails {
+            generation: 2,
+            four_bytes: *b"test",
+        };
+        let d2 = Bogus;
+        let input_data = vec![mother.into()];
+        let output_data = vec![d1.into(), d2.into()];
+
+        assert_eq!(
+            AmoebaMitosis.verify(&input_data, &output_data),
+            Err(VerifierError::BadlyTypedOutput),
+        );
+    }
+
+    #[test]
+    fn mitosis_only_one_output() {
+        let mother = AmoebaDetails {
+            generation: 1,
+            four_bytes: *b"test",
+        };
+        let d1 = AmoebaDetails {
+            generation: 2,
+            four_bytes: *b"test",
+        };
+        let input_data = vec![mother.into()];
+        // There is only one daughter when there should be two
+        let output_data = vec![d1.into()];
+
+        assert_eq!(
+            AmoebaMitosis.verify(&input_data, &output_data),
+            Err(VerifierError::WrongNumberOutputs),
+        );
+    }
+
+    #[test]
+    fn mitosis_too_many_outputs() {
+        let mother = AmoebaDetails {
+            generation: 1,
+            four_bytes: *b"test",
+        };
+        let d1 = AmoebaDetails {
+            generation: 2,
+            four_bytes: *b"test",
+        };
+        let d2 = AmoebaDetails {
+            generation: 2,
+            four_bytes: *b"test",
+        };
+        // Mitosis requires exactly two daughters. There should not be a third one.
+        let d3 = AmoebaDetails {
+            generation: 2,
+            four_bytes: *b"test",
+        };
+        let input_data = vec![mother.into()];
+        let output_data = vec![d1.into(), d2.into(), d3.into()];
+
+        assert_eq!(
+            AmoebaMitosis.verify(&input_data, &output_data),
+            Err(VerifierError::WrongNumberOutputs),
+        );
+    }
 }

--- a/frameless-runtime/src/amoeba.rs
+++ b/frameless-runtime/src/amoeba.rs
@@ -412,4 +412,78 @@ mod test {
             Err(VerifierError::WrongNumberOutputs),
         );
     }
+
+    #[test]
+    fn death_valid_transaction_works() {
+        let example = AmoebaDetails {
+            generation: 1,
+            four_bytes: *b"test",
+        };
+        let input_data = vec![example.into()];
+        let output_data = vec![];
+
+        assert_eq!(
+            AmoebaDeath.verify(&input_data, &output_data),
+            Ok(0),
+        );
+    }
+
+    #[test]
+    fn death_no_input() {
+        let input_data = vec![];
+        let output_data = vec![];
+
+        assert_eq!(
+            AmoebaDeath.verify(&input_data, &output_data),
+            Err(VerifierError::WrongNumberInputs),
+        );
+    }
+
+    #[test]
+    fn death_multiple_inputs() {
+        let a1 = AmoebaDetails {
+            generation: 1,
+            four_bytes: *b"test",
+        };
+        let a2 = AmoebaDetails {
+            generation: 4,
+            four_bytes: *b"test",
+        };
+        let input_data = vec![a1.into(), a2.into()];
+        let output_data = vec![];
+
+        assert_eq!(
+            AmoebaDeath.verify(&input_data, &output_data),
+            Err(VerifierError::WrongNumberInputs),
+        );
+    }
+
+    #[test]
+    fn death_with_output() {
+        let example = AmoebaDetails {
+            generation: 1,
+            four_bytes: *b"test",
+        };
+        let input_data = vec![example.clone().into()];
+        let output_data = vec![example.into()];
+
+        assert_eq!(
+            AmoebaDeath.verify(&input_data, &output_data),
+            Err(VerifierError::WrongNumberOutputs),
+        );
+    }
+
+    #[test]
+    fn death_badly_typed_input() {
+        let example = Bogus;
+        let input_data = vec![example.into()];
+        let output_data = vec![];
+
+        assert_eq!(
+            AmoebaDeath.verify(&input_data, &output_data),
+            Err(VerifierError::BadlyTypedInput),
+        );
+    }
+
+
 }

--- a/frameless-runtime/src/amoeba.rs
+++ b/frameless-runtime/src/amoeba.rs
@@ -172,7 +172,7 @@ impl Verifier for AmoebaCreation {
         ensure!(output_data.len() == 1, VerifierError::WrongNumberOutputs);
         let eve = output_data[0]
             .extract::<AmoebaDetails>()
-            .map_err(|_| VerifierError::BadlyTypedInput)?;
+            .map_err(|_| VerifierError::BadlyTypedOutput)?;
 
         // Make sure the newly created amoeba has generation 0
         ensure!(eve.generation == 0, VerifierError::WrongGeneration);
@@ -206,7 +206,17 @@ mod test {
 
     #[test]
     fn creation_invalid_generation_fails() {
-        todo!()
+        let to_spawn = AmoebaDetails {
+            generation: 100,
+            four_bytes: *b"test",
+        };
+        let input_data = Vec::new();
+        let output_data = vec![to_spawn.into()];
+
+        assert_eq!(
+            AmoebaCreation.verify(&input_data, &output_data),
+            Err(VerifierError::WrongGeneration),
+        );
     }
 
     #[test]
@@ -226,11 +236,27 @@ mod test {
 
     #[test]
     fn creation_with_badly_typed_output_fails() {
-        todo!()
+        let input_data = Vec::new();
+        let output_data = vec![Bogus.into()];
+
+        assert_eq!(
+            AmoebaCreation.verify(&input_data, &output_data),
+            Err(VerifierError::BadlyTypedOutput),
+        );
     }
 
     #[test]
     fn creation_multiple_fails() {
-        todo!()
+        let to_spawn = AmoebaDetails {
+            generation: 0,
+            four_bytes: *b"test",
+        };
+        let input_data = Vec::new();
+        let output_data = vec![to_spawn.clone().into(), to_spawn.into()];
+
+        assert_eq!(
+            AmoebaCreation.verify(&input_data, &output_data),
+            Err(VerifierError::WrongNumberOutputs),
+        );
     }
 }

--- a/frameless-runtime/src/money.rs
+++ b/frameless-runtime/src/money.rs
@@ -146,14 +146,7 @@ impl Verifier for MoneyVerifier {
 #[cfg(test)]
 mod test {
     use super::*;
-
-    /// A bogus data type used in tests for type validation
-    #[derive(Encode, Decode)]
-    struct Bogus;
-
-    impl UtxoData for Bogus {
-        const TYPE_ID: [u8; 4] = *b"bogs";
-    }
+    use tuxedo_core::dynamic_typing::testing::Bogus;
 
     #[test]
     fn spend_valid_transaction_work() {

--- a/tuxedo-core/src/dynamic_typing.rs
+++ b/tuxedo-core/src/dynamic_typing.rs
@@ -119,3 +119,20 @@ impl<T: UtxoData> From<T> for DynamicallyTypedData {
         }
     }
 }
+
+pub mod testing {
+    use super::*;
+
+    /// A bogus data type used in tests.
+    /// 
+    /// When writing tests for individual Tuxedo pieces, developers
+    /// need to make sure that the piece properly sanitizes the dynamically
+    /// typed data that is passed into its verifiers.
+    /// This type is used to represent incorrectly typed data.
+    #[derive(Encode, Decode)]
+    pub struct Bogus;
+
+    impl UtxoData for Bogus {
+        const TYPE_ID: [u8; 4] = *b"bogs";
+    }
+}


### PR DESCRIPTION
This PR primarily adds tests for the amoeba example piece.
It also fixes one small error that the tests found.

And finally, it moves the `Bogus` type from the money piece to a reusable location in the tuxedo core crate so that it can be used in tests for all pieces.