### PR TITLE
CI: Deploy rustdocs to github pages

### DIFF
--- a/.github/workflows/rustdocs.yml
+++ b/.github/workflows/rustdocs.yml
@@ -6,6 +6,10 @@ on:
       - main
       - ci-rustdocs
 
+# So github actions runner can publish the built docs to the gh-pages branch
+permissions:
+  contents: write
+
 jobs:
   deploy-docs:
     name: Deploy docs

--- a/.github/workflows/rustdocs.yml
+++ b/.github/workflows/rustdocs.yml
@@ -1,0 +1,43 @@
+name: Publish Rust Docs
+
+on:
+  push:
+    branches:
+      - main
+      - ci-rustdocs
+
+jobs:
+  deploy-docs:
+    name: Deploy docs
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v1
+
+      - name: Install toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: nightly
+          override: true
+
+      - name: Build rustdocs
+        uses: actions-rs/cargo@v1
+        env:
+          CARGO_INCREMENTAL: "0"
+        with:
+          command: doc
+          args: --all --no-deps
+
+      # Make an index.html file so we start at the tuxedo core
+      # Copied from https://github.com/substrate-developer-hub/rustdocs/blob/master/index.html
+      - name: Make index.html
+        run: echo "<meta http-equiv=refresh content=0;url=tuxedo_core/index.html>" > ./target/doc/index.html
+
+      - name: Deploy documentation
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_branch: gh-pages
+          publish_dir: ./target/doc

--- a/.github/workflows/rustdocs.yml
+++ b/.github/workflows/rustdocs.yml
@@ -15,6 +15,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v1
 
+      - name: Install tooling
+        run: |
+          sudo apt-get install -y protobuf-compiler
+          protoc --version
+
       - name: Install toolchain
         uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/rustdocs.yml
+++ b/.github/workflows/rustdocs.yml
@@ -25,6 +25,7 @@ jobs:
         with:
           profile: minimal
           toolchain: nightly
+          target: wasm32-unknown-unknown
           override: true
 
       - name: Build rustdocs

--- a/.gitignore
+++ b/.gitignore
@@ -11,8 +11,5 @@
 # The cache for docker container dependency
 .cargo
 
-# The cache for chain data in container
-.local
-
 # direnv cache
 .direnv

--- a/.gitignore
+++ b/.gitignore
@@ -11,5 +11,8 @@
 # The cache for docker container dependency
 .cargo
 
+# The cache for chain data in container
+.local
+
 # direnv cache
 .direnv


### PR DESCRIPTION
This PR adds a second CI workflow to deploy our rustdocs to github pages for easy reference by developers, grant reviewers, and anyone else.