### PR TITLE
Test tuxedo core

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -216,6 +216,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f52f63c5c1316a16a4b35eaac8b76a98248961a533f061684cb2a7cb0eafb6c6"
 
 [[package]]
+name = "array-bytes"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22f72e9d6fac4bc80778ea470b20197b88d28c292bb7d60c3fb099280003cd19"
+
+[[package]]
 name = "arrayref"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5347,7 +5353,7 @@ name = "sc-cli"
 version = "0.10.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?tag=monthly-2023-03#ad5399644aebc54e32a107ac37ae08e6cd1f0cfb"
 dependencies = [
- "array-bytes",
+ "array-bytes 4.2.0",
  "chrono",
  "clap",
  "fdlimit",
@@ -5494,7 +5500,7 @@ version = "0.10.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?tag=monthly-2023-03#ad5399644aebc54e32a107ac37ae08e6cd1f0cfb"
 dependencies = [
  "ahash 0.8.3",
- "array-bytes",
+ "array-bytes 4.2.0",
  "async-trait",
  "dyn-clone",
  "finality-grandpa",
@@ -5639,7 +5645,7 @@ name = "sc-keystore"
 version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?tag=monthly-2023-03#ad5399644aebc54e32a107ac37ae08e6cd1f0cfb"
 dependencies = [
- "array-bytes",
+ "array-bytes 4.2.0",
  "async-trait",
  "parking_lot 0.12.1",
  "serde_json",
@@ -5654,7 +5660,7 @@ name = "sc-network"
 version = "0.10.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?tag=monthly-2023-03#ad5399644aebc54e32a107ac37ae08e6cd1f0cfb"
 dependencies = [
- "array-bytes",
+ "array-bytes 4.2.0",
  "async-trait",
  "asynchronous-codec",
  "backtrace",
@@ -5760,7 +5766,7 @@ name = "sc-network-light"
 version = "0.10.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?tag=monthly-2023-03#ad5399644aebc54e32a107ac37ae08e6cd1f0cfb"
 dependencies = [
- "array-bytes",
+ "array-bytes 4.2.0",
  "futures",
  "libp2p",
  "log",
@@ -5781,7 +5787,7 @@ name = "sc-network-sync"
 version = "0.10.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?tag=monthly-2023-03#ad5399644aebc54e32a107ac37ae08e6cd1f0cfb"
 dependencies = [
- "array-bytes",
+ "array-bytes 4.2.0",
  "async-trait",
  "fork-tree",
  "futures",
@@ -5813,7 +5819,7 @@ name = "sc-network-transactions"
 version = "0.10.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?tag=monthly-2023-03#ad5399644aebc54e32a107ac37ae08e6cd1f0cfb"
 dependencies = [
- "array-bytes",
+ "array-bytes 4.2.0",
  "futures",
  "libp2p",
  "log",
@@ -5832,7 +5838,7 @@ name = "sc-offchain"
 version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?tag=monthly-2023-03#ad5399644aebc54e32a107ac37ae08e6cd1f0cfb"
 dependencies = [
- "array-bytes",
+ "array-bytes 4.2.0",
  "bytes",
  "fnv",
  "futures",
@@ -5948,7 +5954,7 @@ name = "sc-rpc-spec-v2"
 version = "0.10.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?tag=monthly-2023-03#ad5399644aebc54e32a107ac37ae08e6cd1f0cfb"
 dependencies = [
- "array-bytes",
+ "array-bytes 4.2.0",
  "futures",
  "futures-util",
  "hex",
@@ -6757,7 +6763,7 @@ name = "sp-core"
 version = "7.0.0"
 source = "git+https://github.com/paritytech/substrate.git?tag=monthly-2023-03#ad5399644aebc54e32a107ac37ae08e6cd1f0cfb"
 dependencies = [
- "array-bytes",
+ "array-bytes 4.2.0",
  "base58",
  "bitflags",
  "blake2",
@@ -7922,6 +7928,7 @@ dependencies = [
 name = "tuxedo-core"
 version = "1.0.0-dev"
 dependencies = [
+ "array-bytes 6.0.0",
  "log",
  "parity-scale-codec",
  "parity-util-mem",

--- a/tuxedo-core/Cargo.toml
+++ b/tuxedo-core/Cargo.toml
@@ -21,6 +21,9 @@ sp-runtime = { git = 'https://github.com/paritytech/substrate', tag = "monthly-2
 sp-std = { git = 'https://github.com/paritytech/substrate', tag = "monthly-2023-03", default_features = false}
 sp-storage = { git = 'https://github.com/paritytech/substrate', tag = "monthly-2023-03", default_features = false}
 
+[dev-dependencies]
+array-bytes = "6.0.0"
+
 [features]
 default = ["std"]
 std = [

--- a/tuxedo-core/src/dynamic_typing.rs
+++ b/tuxedo-core/src/dynamic_typing.rs
@@ -200,4 +200,20 @@ mod tests {
 
         assert_eq!(extracted_b, Err(DynamicTypingError::DecodingFailed));
     }
+
+    #[test]
+    fn display_wrong_type_error() {
+        let actual = format!("{}", DynamicTypingError::WrongType);
+        let expected = String::from("dynamic type does not match extraction target");
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn display_decoding_failed_error() {
+        let actual = format!("{}", DynamicTypingError::DecodingFailed);
+        let expected = String::from("failed to decode dynamically typed data with scale codec");
+
+        assert_eq!(actual, expected);
+    }
 }

--- a/tuxedo-core/src/dynamic_typing.rs
+++ b/tuxedo-core/src/dynamic_typing.rs
@@ -91,7 +91,7 @@ impl DynamicallyTypedData {
 }
 
 /// Errors that can occur when casting dynamically typed data into strongly typed data.
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum DynamicTypingError {
     /// The data provided was not of the target decoding type.
     WrongType,
@@ -139,16 +139,65 @@ impl<T: UtxoData> From<T> for DynamicallyTypedData {
 pub mod testing {
     use super::*;
 
-    /// A bogus data type used in tests.
+    /// A bogus data type for use in tests.
     ///
     /// When writing tests for individual Tuxedo pieces, developers
     /// need to make sure that the piece properly sanitizes the dynamically
     /// typed data that is passed into its verifiers.
     /// This type is used to represent incorrectly typed data.
-    #[derive(Encode, Decode)]
+    #[derive(Encode, Decode, PartialEq, Eq, Debug)]
     pub struct Bogus;
 
     impl UtxoData for Bogus {
         const TYPE_ID: [u8; 4] = *b"bogs";
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use testing::Bogus;
+
+    /// A simple type that implements UtxoData and just wraps a single u8.
+    /// Used to test the extraction logic.
+    #[derive(Encode, Decode, Debug, PartialEq, Eq, Clone)]
+    struct Byte(u8);
+
+    impl UtxoData for Byte{
+        const TYPE_ID: [u8; 4] = *b"byte";
+    }
+
+
+    #[test]
+    fn extract_works() {
+        let original_b = Byte(4);
+        let dynamically_typed_b: DynamicallyTypedData = original_b.clone().into();
+
+        let extracted_b = dynamically_typed_b.extract::<Byte>();
+
+        assert_eq!(extracted_b, Ok(original_b));
+    }
+
+    #[test]
+    fn extract_wrong_type() {
+        let original_b = Byte(4);
+        let dynamically_typed_b: DynamicallyTypedData = original_b.clone().into();
+
+        let extracted_b = dynamically_typed_b.extract::<Bogus>();
+
+        assert_eq!(extracted_b, Err(DynamicTypingError::WrongType));
+    }
+
+    #[test]
+    fn extract_decode_fails() {
+        let original_b = Byte(4);
+        let mut dynamically_typed_b: DynamicallyTypedData = original_b.clone().into();
+
+        // Change the encoded bytes so they no longer decode correctly.
+        dynamically_typed_b.data = Vec::new();
+
+        let extracted_b = dynamically_typed_b.extract::<Byte>();
+
+        assert_eq!(extracted_b, Err(DynamicTypingError::DecodingFailed));
     }
 }

--- a/tuxedo-core/src/dynamic_typing.rs
+++ b/tuxedo-core/src/dynamic_typing.rs
@@ -163,10 +163,9 @@ mod tests {
     #[derive(Encode, Decode, Debug, PartialEq, Eq, Clone)]
     struct Byte(u8);
 
-    impl UtxoData for Byte{
+    impl UtxoData for Byte {
         const TYPE_ID: [u8; 4] = *b"byte";
     }
-
 
     #[test]
     fn extract_works() {

--- a/tuxedo-core/src/executive.rs
+++ b/tuxedo-core/src/executive.rs
@@ -540,6 +540,30 @@ mod tests {
                 };
 
                 let tx = TestTransaction {
+                    inputs: vec![input.clone(), input],
+                    outputs: Vec::new(),
+                    verifier: TestVerifier{ verifies: true },
+                };
+
+                let result = TestExecutive::validate_tuxedo_transaction(&tx);
+
+                assert_eq!(result, Err(UtxoError::DuplicateInput));
+            });
+    }
+
+    #[test]
+    fn validate_with_unsatisfied_redeemer_fails() {
+        ExternalityBuilder::default()
+            .with_utxo(0, 0, Bogus, false)
+            .build()
+            .execute_with(||{
+                let output_ref = mock_output_ref(0, 0);
+                let input = Input {
+                    output_ref,
+                    witness: Vec::new(),
+                };
+
+                let tx = TestTransaction {
                     inputs: vec![input],
                     outputs: Vec::new(),
                     verifier: TestVerifier{ verifies: true },
@@ -549,21 +573,6 @@ mod tests {
 
                 assert_eq!(result, Err(UtxoError::RedeemerError));
             });
-    }
-
-    #[test]
-    fn validate_with_unsatisfied_redeemer_fails() {
-        let tx = TestTransaction {
-            inputs: Vec::new(),
-            outputs: Vec::new(),
-            verifier: TestVerifier{ verifies: true },
-        };
-
-        let vt = TestExecutive::validate_tuxedo_transaction(&tx).unwrap();
-
-        let expected_result = ValidTransactionBuilder::default().into();
-
-        assert_eq!(vt, expected_result);
     }
 
     #[test]

--- a/tuxedo-core/src/executive.rs
+++ b/tuxedo-core/src/executive.rs
@@ -439,13 +439,7 @@ mod tests {
 
         let vt = TestExecutive::validate_tuxedo_transaction(&tx).unwrap();
 
-        let expected_result = ValidTransaction {
-            priority: 0,
-            requires: Vec::new(),
-            provides: Vec::new(),
-            longevity: TransactionLongevity::max_value(),
-            propagate: true,
-        };
+        let expected_result = ValidTransactionBuilder::default().into();
 
         assert_eq!(vt, expected_result);
     }
@@ -471,13 +465,7 @@ mod tests {
 
                 let vt = TestExecutive::validate_tuxedo_transaction(&tx).unwrap();
 
-                let expected_result = ValidTransaction {
-                    priority: 0,
-                    requires: Vec::new(),
-                    provides: Vec::new(),
-                    longevity: TransactionLongevity::max_value(),
-                    propagate: true,
-                };
+                let expected_result = ValidTransactionBuilder::default().into();
 
                 assert_eq!(vt, expected_result);
             });
@@ -507,13 +495,7 @@ mod tests {
 
                 let vt = TestExecutive::validate_tuxedo_transaction(&tx).unwrap();
 
-                let expected_result = ValidTransaction {
-                    priority: 0,
-                    requires: Vec::new(),
-                    provides: vec![output_ref.encode()],
-                    longevity: TransactionLongevity::max_value(),
-                    propagate: true,
-                };
+                let expected_result = ValidTransactionBuilder::default().and_provides(output_ref).into();
 
                 assert_eq!(vt, expected_result);
             });
@@ -539,13 +521,7 @@ mod tests {
 
                 let vt = TestExecutive::validate_tuxedo_transaction(&tx).unwrap();
 
-                let expected_result = ValidTransaction {
-                    priority: 0,
-                    requires: vec![output_ref.encode()],
-                    provides: Vec::new(),
-                    longevity: TransactionLongevity::max_value(),
-                    propagate: true,
-                };
+                let expected_result = ValidTransactionBuilder::default().and_requires(output_ref).into();
 
                 assert_eq!(vt, expected_result);
             });
@@ -585,13 +561,7 @@ mod tests {
 
         let vt = TestExecutive::validate_tuxedo_transaction(&tx).unwrap();
 
-        let expected_result = ValidTransaction {
-            priority: 0,
-            requires: Vec::new(),
-            provides: Vec::new(),
-            longevity: TransactionLongevity::max_value(),
-            propagate: true,
-        };
+        let expected_result = ValidTransactionBuilder::default().into();
 
         assert_eq!(vt, expected_result);
     }

--- a/tuxedo-core/src/executive.rs
+++ b/tuxedo-core/src/executive.rs
@@ -358,3 +358,52 @@ impl<B: BlockT<Extrinsic = Transaction<R, V>>, R: Redeemer, V: Verifier> Executi
         r.map_err(|_| TransactionValidityError::Invalid(InvalidTransaction::Custom(0)))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Builds externalities using the builder pattern.
+    //struct ExternalityBuilder<R: Redeemer>(Vec<(OutputRef, Output<R>)>);
+
+    #[test]
+    fn validate_empty_works() {
+        todo!()
+    }
+
+    #[test]
+    fn validate_with_input_works() {
+        todo!()
+    }
+
+    #[test]
+    fn validate_with_output_works() {
+        todo!()
+    }
+
+    #[test]
+    fn validate_with_missing_input_works() {
+        todo!()
+    }
+
+    #[test]
+    fn validate_with_duplicate_input_fails() {
+        todo!()
+    }
+
+    #[test]
+    fn validate_with_unsatisfied_redeemer_fails() {
+        todo!()
+    }
+
+    #[test]
+    fn validate_with_pre_existing_output_fails() {
+        todo!()
+    }
+
+    #[test]
+    fn validate_with_verifier_error_fails() {
+        todo!()
+    }
+
+}

--- a/tuxedo-core/src/executive.rs
+++ b/tuxedo-core/src/executive.rs
@@ -311,7 +311,11 @@ impl<B: BlockT<Extrinsic = Transaction<R, V>>, R: Redeemer, V: Verifier> Executi
         let raw_state_root = &sp_io::storage::root(StateVersion::V1)[..];
         let state_root =
             <<B as BlockT>::Header as HeaderT>::Hash::decode(&mut &raw_state_root[..]).unwrap();
-        assert_eq!(*block.header().state_root(), state_root, "state root mismatch");
+        assert_eq!(
+            *block.header().state_root(),
+            state_root,
+            "state root mismatch"
+        );
 
         // Print state for quick debugging
         // let mut key = vec![];
@@ -336,7 +340,11 @@ impl<B: BlockT<Extrinsic = Transaction<R, V>>, R: Redeemer, V: Verifier> Executi
             extrinsics,
             StateVersion::V1,
         );
-        assert_eq!(*block.header().extrinsics_root(), extrinsics_root, "extrinsics root mismatch");
+        assert_eq!(
+            *block.header().extrinsics_root(),
+            extrinsics_root,
+            "extrinsics root mismatch"
+        );
     }
 
     // This one is the pool api. It is used to make preliminary checks in the transaction pool
@@ -876,26 +884,118 @@ mod tests {
 
     #[test]
     fn execute_empty_block_works() {
-        todo!()
+        ExternalityBuilder::default().build().execute_with(|| {
+            let b = TestBlock {
+                header: TestHeader {
+                    parent_hash: H256::zero(),
+                    number: 6,
+                    state_root: array_bytes::hex_n_into_unchecked(
+                        "858174d563f845dbb4959ea64816bd8409e48cc7e65db8aa455bc98d61d24071",
+                    ),
+                    extrinsics_root: array_bytes::hex_n_into_unchecked(
+                        "03170a2e7597b7b7e3d84c05391d139a62b157e78786d8c082f29dcf4c111314",
+                    ),
+                    digest: Default::default(),
+                },
+                extrinsics: Vec::new(),
+            };
+
+            TestExecutive::execute_block(b);
+        });
     }
 
     #[test]
     fn execute_block_with_transaction_works() {
-        todo!()
+        ExternalityBuilder::default().build().execute_with(|| {
+            let b = TestBlock {
+                header: TestHeader {
+                    parent_hash: H256::zero(),
+                    number: 6,
+                    state_root: array_bytes::hex_n_into_unchecked(
+                        "858174d563f845dbb4959ea64816bd8409e48cc7e65db8aa455bc98d61d24071",
+                    ),
+                    extrinsics_root: array_bytes::hex_n_into_unchecked(
+                        "7ceffb73687cb9af3ad2f9a0c544a216df70894b03da3ceb57ead37bd6b51be0",
+                    ),
+                    digest: Default::default(),
+                },
+                extrinsics: vec![TestTransaction {
+                    inputs: Vec::new(),
+                    outputs: Vec::new(),
+                    verifier: TestVerifier { verifies: true },
+                }],
+            };
+
+            TestExecutive::execute_block(b);
+        });
     }
 
     #[test]
-    fn execute_block_invalid_transaction_fails() {
-        todo!()
+    #[should_panic(expected = "VerifierError(())")]
+    fn execute_block_invalid_transaction() {
+        ExternalityBuilder::default().build().execute_with(|| {
+            let b = TestBlock {
+                header: TestHeader {
+                    parent_hash: H256::zero(),
+                    number: 6,
+                    state_root: array_bytes::hex_n_into_unchecked(
+                        "858174d563f845dbb4959ea64816bd8409e48cc7e65db8aa455bc98d61d24071",
+                    ),
+                    extrinsics_root: array_bytes::hex_n_into_unchecked(
+                        "03170a2e7597b7b7e3d84c05391d139a62b157e78786d8c082f29dcf4c111314",
+                    ),
+                    digest: Default::default(),
+                },
+                extrinsics: vec![TestTransaction {
+                    inputs: Vec::new(),
+                    outputs: Vec::new(),
+                    verifier: TestVerifier { verifies: false },
+                }],
+            };
+
+            TestExecutive::execute_block(b);
+        });
     }
 
     #[test]
-    fn execute_block_state_root_mismatch_works() {
-        todo!()
+    #[should_panic(expected = "state root mismatch")]
+    fn execute_block_state_root_mismatch() {
+        ExternalityBuilder::default().build().execute_with(|| {
+            let b = TestBlock {
+                header: TestHeader {
+                    parent_hash: H256::zero(),
+                    number: 6,
+                    state_root: H256::zero(),
+                    extrinsics_root: array_bytes::hex_n_into_unchecked(
+                        "03170a2e7597b7b7e3d84c05391d139a62b157e78786d8c082f29dcf4c111314",
+                    ),
+                    digest: Default::default(),
+                },
+                extrinsics: Vec::new(),
+            };
+
+            TestExecutive::execute_block(b);
+        });
     }
 
     #[test]
+    #[should_panic(expected = "extrinsics root mismatch")]
     fn execute_block_extrinsic_root_mismatch() {
-        todo!()
+        ExternalityBuilder::default().build().execute_with(|| {
+            let b = TestBlock {
+                header: TestHeader {
+                    parent_hash: H256::zero(),
+                    number: 6,
+                    state_root: array_bytes::hex_n_into_unchecked(
+                        "858174d563f845dbb4959ea64816bd8409e48cc7e65db8aa455bc98d61d24071",
+                    ),
+                    extrinsics_root: H256::zero(),
+                    digest: Default::default(),
+                },
+                extrinsics: Vec::new(),
+            };
+
+            TestExecutive::execute_block(b);
+        });
     }
 }

--- a/tuxedo-core/src/executive.rs
+++ b/tuxedo-core/src/executive.rs
@@ -553,26 +553,47 @@ mod tests {
 
     #[test]
     fn validate_with_duplicate_input_fails() {
-        let output_ref = mock_output_ref(0, 0);
-        let input = Input {
-            output_ref: output_ref.clone(),
-            witness: Vec::new(),
-        };
+        ExternalityBuilder::default()
+            .with_utxo(0, 0, Bogus, false)
+            .build()
+            .execute_with(||{
+                let output_ref = mock_output_ref(0, 0);
+                let input = Input {
+                    output_ref,
+                    witness: Vec::new(),
+                };
 
-        let tx = TestTransaction {
-            inputs: vec![input.clone(), input],
-            outputs: Vec::new(),
-            verifier: TestVerifier{ verifies: true },
-        };
+                let tx = TestTransaction {
+                    inputs: vec![input],
+                    outputs: Vec::new(),
+                    verifier: TestVerifier{ verifies: true },
+                };
 
-        let result = TestExecutive::validate_tuxedo_transaction(&tx);
+                let result = TestExecutive::validate_tuxedo_transaction(&tx);
 
-        assert_eq!(result, Err(UtxoError::DuplicateInput));
+                assert_eq!(result, Err(UtxoError::RedeemerError));
+            });
     }
 
     #[test]
     fn validate_with_unsatisfied_redeemer_fails() {
-        todo!()
+        let tx = TestTransaction {
+            inputs: Vec::new(),
+            outputs: Vec::new(),
+            verifier: TestVerifier{ verifies: true },
+        };
+
+        let vt = TestExecutive::validate_tuxedo_transaction(&tx).unwrap();
+
+        let expected_result = ValidTransaction {
+            priority: 0,
+            requires: Vec::new(),
+            provides: Vec::new(),
+            longevity: TransactionLongevity::max_value(),
+            propagate: true,
+        };
+
+        assert_eq!(vt, expected_result);
     }
 
     #[test]

--- a/tuxedo-core/src/executive.rs
+++ b/tuxedo-core/src/executive.rs
@@ -631,7 +631,20 @@ mod tests {
 
     #[test]
     fn validate_with_verifier_error_fails() {
-        todo!()
+        ExternalityBuilder::default()
+            .build()
+            .execute_with(||{
+
+                let tx = TestTransaction {
+                    inputs: Vec::new(),
+                    outputs: Vec::new(),
+                    verifier: TestVerifier{ verifies: false },
+                };
+
+                let vt = TestExecutive::validate_tuxedo_transaction(&tx);
+
+                assert_eq!(vt, Err(UtxoError::VerifierError(())));
+            });
     }
 
 }

--- a/tuxedo-core/src/executive.rs
+++ b/tuxedo-core/src/executive.rs
@@ -311,7 +311,7 @@ impl<B: BlockT<Extrinsic = Transaction<R, V>>, R: Redeemer, V: Verifier> Executi
         let raw_state_root = &sp_io::storage::root(StateVersion::V1)[..];
         let state_root =
             <<B as BlockT>::Header as HeaderT>::Hash::decode(&mut &raw_state_root[..]).unwrap();
-        assert_eq!(*block.header().state_root(), state_root);
+        assert_eq!(*block.header().state_root(), state_root, "state root mismatch");
 
         // Print state for quick debugging
         // let mut key = vec![];
@@ -336,7 +336,7 @@ impl<B: BlockT<Extrinsic = Transaction<R, V>>, R: Redeemer, V: Verifier> Executi
             extrinsics,
             StateVersion::V1,
         );
-        assert_eq!(*block.header().extrinsics_root(), extrinsics_root);
+        assert_eq!(*block.header().extrinsics_root(), extrinsics_root, "extrinsics root mismatch");
     }
 
     // This one is the pool api. It is used to make preliminary checks in the transaction pool
@@ -872,5 +872,30 @@ mod tests {
                 assert!(!sp_io::storage::exists(&HEADER_KEY));
                 assert!(!sp_io::storage::exists(&EXTRINSIC_KEY));
             });
+    }
+
+    #[test]
+    fn execute_empty_block_works() {
+        todo!()
+    }
+
+    #[test]
+    fn execute_block_with_transaction_works() {
+        todo!()
+    }
+
+    #[test]
+    fn execute_block_invalid_transaction_fails() {
+        todo!()
+    }
+
+    #[test]
+    fn execute_block_state_root_mismatch_works() {
+        todo!()
+    }
+
+    #[test]
+    fn execute_block_extrinsic_root_mismatch() {
+        todo!()
     }
 }

--- a/tuxedo-core/src/executive.rs
+++ b/tuxedo-core/src/executive.rs
@@ -552,7 +552,21 @@ mod tests {
 
     #[test]
     fn validate_with_duplicate_input_fails() {
-        todo!()
+        let output_ref = mock_output_ref(0, 0);
+        let input = Input {
+            output_ref: output_ref.clone(),
+            witness: Vec::new(),
+        };
+
+        let tx = TestTransaction {
+            inputs: vec![input.clone(), input],
+            outputs: Vec::new(),
+            verifier: TestVerifier{ verifies: true },
+        };
+
+        let result = TestExecutive::validate_tuxedo_transaction(&tx);
+
+        assert_eq!(result, Err(UtxoError::DuplicateInput));
     }
 
     #[test]

--- a/tuxedo-core/src/executive.rs
+++ b/tuxedo-core/src/executive.rs
@@ -626,4 +626,46 @@ mod tests {
             });
     }
 
+    #[test]
+    fn apply_empty_works() {
+        ExternalityBuilder::default()
+            .build()
+            .execute_with(||{
+
+                let tx = TestTransaction {
+                    inputs: Vec::new(),
+                    outputs: Vec::new(),
+                    verifier: TestVerifier{ verifies: true },
+                };
+
+                let vt = TestExecutive::apply_tuxedo_transaction(tx);
+
+                assert_eq!(vt, Ok(()));
+            });
+    }
+
+    #[test]
+    fn apply_with_missing_input_fails() {
+        ExternalityBuilder::default()
+            .build()
+            .execute_with(||{
+
+                let output_ref = mock_output_ref(0, 0);
+                let input = Input {
+                    output_ref: output_ref.clone(),
+                    witness: Vec::new(),
+                };
+
+                let tx = TestTransaction {
+                    inputs: vec![input],
+                    outputs: Vec::new(),
+                    verifier: TestVerifier{ verifies: true },
+                };
+
+                let vt = TestExecutive::apply_tuxedo_transaction(tx);
+
+                assert_eq!(vt, Err(UtxoError::MissingInput));
+            });
+    }
+
 }

--- a/tuxedo-core/src/executive.rs
+++ b/tuxedo-core/src/executive.rs
@@ -361,14 +361,37 @@ impl<B: BlockT<Extrinsic = Transaction<R, V>>, R: Redeemer, V: Verifier> Executi
 
 #[cfg(test)]
 mod tests {
+    use crate::{verifier::testing::TestVerifier, redeemer::TestRedeemer};
+
     use super::*;
+
+    type TestTransaction = Transaction<TestRedeemer, TestVerifier>;
+    pub type TestHeader = sp_runtime::generic::Header<u32, BlakeTwo256>;
+    pub type TestBlock = sp_runtime::generic::Block<TestHeader, TestTransaction>;
+    pub type TestExecutive = Executive<TestBlock, TestRedeemer, TestVerifier>;
 
     // Builds externalities using the builder pattern.
     //struct ExternalityBuilder<R: Redeemer>(Vec<(OutputRef, Output<R>)>);
 
     #[test]
     fn validate_empty_works() {
-        todo!()
+        let tx = TestTransaction {
+            inputs: Vec::new(),
+            outputs: Vec::new(),
+            verifier: TestVerifier{ verifies: true },
+        };
+
+        let vt = TestExecutive::validate_tuxedo_transaction(&tx).unwrap();
+
+        let expected_result = ValidTransaction {
+            priority: 0,
+            requires: Vec::new(),
+            provides: Vec::new(),
+            longevity: TransactionLongevity::max_value(),
+            propagate: true,
+        };
+
+        assert_eq!(vt, expected_result);
     }
 
     #[test]

--- a/tuxedo-core/src/redeemer.rs
+++ b/tuxedo-core/src/redeemer.rs
@@ -63,6 +63,7 @@ pub struct TestRedeemer {
     pub redeems: bool,
 }
 
+#[cfg(feature = "std")]
 impl Redeemer for TestRedeemer {
     fn redeem(&self, _simplified_tx: &[u8], _witness: &[u8]) -> bool {
         self.redeems

--- a/tuxedo-core/src/redeemer.rs
+++ b/tuxedo-core/src/redeemer.rs
@@ -107,13 +107,13 @@ mod test {
 
     #[test]
     fn test_redeemer_passes() {
-        let result = TestRedeemer{redeems: true}.redeem(&[], &[]);
+        let result = TestRedeemer { redeems: true }.redeem(&[], &[]);
         assert_eq!(result, true);
     }
 
     #[test]
     fn test_redeemer_fails() {
-        let result = TestRedeemer{redeems: false}.redeem(&[], &[]);
+        let result = TestRedeemer { redeems: false }.redeem(&[], &[]);
         assert_eq!(result, false);
     }
 }

--- a/tuxedo-core/src/redeemer.rs
+++ b/tuxedo-core/src/redeemer.rs
@@ -54,6 +54,21 @@ impl Redeemer for UpForGrabs {
     }
 }
 
+/// A testing redeemer that passes or depending on the enclosed
+/// boolean value.
+#[cfg(feature = "std")]
+#[derive(Serialize, Deserialize, Encode, Decode, Debug, PartialEq, Eq, Clone)]
+pub struct TestRedeemer {
+    /// Whether the redeemer should pass
+    pub redeems: bool,
+}
+
+impl Redeemer for TestRedeemer {
+    fn redeem(&self, _simplified_tx: &[u8], _witness: &[u8]) -> bool {
+        self.redeems
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::*;
@@ -88,5 +103,17 @@ mod test {
         };
 
         assert!(!sig_check.redeem(simplified_tx, witness));
+    }
+
+    #[test]
+    fn test_redeemer_passes() {
+        let result = TestRedeemer{redeems: true}.redeem(&[], &[]);
+        assert_eq!(result, true);
+    }
+
+    #[test]
+    fn test_redeemer_fails() {
+        let result = TestRedeemer{redeems: false}.redeem(&[], &[]);
+        assert_eq!(result, false);
     }
 }

--- a/tuxedo-core/src/types.rs
+++ b/tuxedo-core/src/types.rs
@@ -123,8 +123,12 @@ pub mod tests {
 
     #[test]
     fn extrinsic_no_signed_payload() {
-        let verifier = TestVerifier{ verifies: true };
-        let tx: Transaction<UpForGrabs, TestVerifier> = Transaction { inputs: Vec::new(), outputs: Vec::new(), verifier, };
+        let verifier = TestVerifier { verifies: true };
+        let tx: Transaction<UpForGrabs, TestVerifier> = Transaction {
+            inputs: Vec::new(),
+            outputs: Vec::new(),
+            verifier,
+        };
         let e = Transaction::new(tx.clone(), None).unwrap();
 
         assert_eq!(e, tx);
@@ -133,8 +137,12 @@ pub mod tests {
 
     #[test]
     fn extrinsic_is_signed_works() {
-        let verifier = TestVerifier{ verifies: true };
-        let tx: Transaction<UpForGrabs, TestVerifier> = Transaction { inputs: Vec::new(), outputs: Vec::new(), verifier, };
+        let verifier = TestVerifier { verifies: true };
+        let tx: Transaction<UpForGrabs, TestVerifier> = Transaction {
+            inputs: Vec::new(),
+            outputs: Vec::new(),
+            verifier,
+        };
         let e = Transaction::new(tx.clone(), Some(())).unwrap();
 
         assert_eq!(e, tx);

--- a/tuxedo-core/src/types.rs
+++ b/tuxedo-core/src/types.rs
@@ -117,13 +117,14 @@ pub struct Output<R> {
 #[cfg(test)]
 pub mod tests {
 
-    use crate::{redeemer::UpForGrabs, verifier::testing::AlwaysVerifies};
+    use crate::{redeemer::UpForGrabs, verifier::testing::TestVerifier};
 
     use super::*;
 
     #[test]
     fn extrinsic_no_signed_payload() {
-        let tx: Transaction<UpForGrabs, AlwaysVerifies> = Transaction { inputs: Vec::new(), outputs: Vec::new(), verifier: AlwaysVerifies };
+        let verifier = TestVerifier{ verifies: true };
+        let tx: Transaction<UpForGrabs, TestVerifier> = Transaction { inputs: Vec::new(), outputs: Vec::new(), verifier, };
         let e = Transaction::new(tx.clone(), None).unwrap();
 
         assert_eq!(e, tx);
@@ -132,7 +133,8 @@ pub mod tests {
 
     #[test]
     fn extrinsic_is_signed_works() {
-        let tx: Transaction<UpForGrabs, AlwaysVerifies> = Transaction { inputs: Vec::new(), outputs: Vec::new(), verifier: AlwaysVerifies };
+        let verifier = TestVerifier{ verifies: true };
+        let tx: Transaction<UpForGrabs, TestVerifier> = Transaction { inputs: Vec::new(), outputs: Vec::new(), verifier, };
         let e = Transaction::new(tx.clone(), Some(())).unwrap();
 
         assert_eq!(e, tx);

--- a/tuxedo-core/src/types.rs
+++ b/tuxedo-core/src/types.rs
@@ -113,3 +113,29 @@ pub struct Output<R> {
     pub payload: DynamicallyTypedData,
     pub redeemer: R,
 }
+
+#[cfg(test)]
+pub mod tests {
+
+    use crate::{redeemer::UpForGrabs, verifier::testing::AlwaysVerifies};
+
+    use super::*;
+
+    #[test]
+    fn extrinsic_no_signed_payload() {
+        let tx: Transaction<UpForGrabs, AlwaysVerifies> = Transaction { inputs: Vec::new(), outputs: Vec::new(), verifier: AlwaysVerifies };
+        let e = Transaction::new(tx.clone(), None).unwrap();
+
+        assert_eq!(e, tx);
+        assert_eq!(e.is_signed(), Some(false));
+    }
+
+    #[test]
+    fn extrinsic_is_signed_works() {
+        let tx: Transaction<UpForGrabs, AlwaysVerifies> = Transaction { inputs: Vec::new(), outputs: Vec::new(), verifier: AlwaysVerifies };
+        let e = Transaction::new(tx.clone(), Some(())).unwrap();
+
+        assert_eq!(e, tx);
+        assert_eq!(e.is_signed(), Some(false));
+    }
+}

--- a/tuxedo-core/src/types.rs
+++ b/tuxedo-core/src/types.rs
@@ -81,7 +81,7 @@ pub struct Input {
     pub witness: Vec<u8>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum UtxoError<VerifierError> {
     /// This transaction defines the same input multiple times
     DuplicateInput,

--- a/tuxedo-core/src/utxo_set.rs
+++ b/tuxedo-core/src/utxo_set.rs
@@ -4,7 +4,8 @@
 
 use crate::{
     redeemer::Redeemer,
-    types::{Output, OutputRef}, LOG_TARGET,
+    types::{Output, OutputRef},
+    LOG_TARGET,
 };
 use parity_scale_codec::{Decode, Encode};
 use sp_std::marker::PhantomData;

--- a/tuxedo-core/src/verifier.rs
+++ b/tuxedo-core/src/verifier.rs
@@ -33,11 +33,15 @@ pub mod testing {
 
     use super::*;
 
-    /// A testing verifier that verifies everything.
+    /// A testing verifier that passes (with zero priority) or not depending on
+    /// the boolean value enclosed.
     #[derive(Encode, Decode, Debug, Clone, PartialEq, Eq)]
-    pub struct AlwaysVerifies;
+    pub struct TestVerifier {
+        /// Whether the verifier should pass.
+        pub verifies: bool,
+    }
 
-    impl Verifier for AlwaysVerifies {
+    impl Verifier for TestVerifier {
         type Error = ();
 
         fn verify(
@@ -45,23 +49,23 @@ pub mod testing {
             _input_data: &[DynamicallyTypedData],
             _output_data: &[DynamicallyTypedData],
         ) -> Result<TransactionPriority, ()> {
-            Ok(0)
+            if self.verifies {
+                Ok(0)
+            } else {
+                Err(())
+            }
         }
     }
 
-    /// A testing verifier that verifies nothing.
-    #[derive(Encode, Decode, Debug, Clone, PartialEq, Eq)]
-    pub struct NeverVerifies;
+    #[test]
+    fn test_verifier_passes() {
+        let result = TestVerifier{verifies: true}.verify(&[], &[]);
+        assert_eq!(result, Ok(0));
+    }
 
-    impl Verifier for NeverVerifies {
-        type Error = ();
-
-        fn verify(
-            &self,
-            _input_data: &[DynamicallyTypedData],
-            _output_data: &[DynamicallyTypedData],
-        ) -> Result<TransactionPriority, ()> {
-            Err(())
-        }
+    #[test]
+    fn test_verifier_fails() {
+        let result = TestVerifier{verifies: false}.verify(&[], &[]);
+        assert_eq!(result, Err(()));
     }
 }

--- a/tuxedo-core/src/verifier.rs
+++ b/tuxedo-core/src/verifier.rs
@@ -8,6 +8,8 @@ use sp_std::fmt::Debug;
 use crate::dynamic_typing::DynamicallyTypedData;
 use parity_scale_codec::{Decode, Encode};
 use sp_runtime::transaction_validity::TransactionPriority;
+#[cfg(feature = "std")]
+use serde::{Deserialize, Serialize};
 
 /// A single verifier that a transaction can choose to call. Verifies whether the input
 /// and output data from a transaction meets the codified constraints.
@@ -28,14 +30,15 @@ pub trait Verifier: Debug + Encode + Decode + Clone {
 }
 
 
-/// Simple verifiers for use in unit tests. Not for use in production runtimes.
+/// Simple verifier for use in unit tests. Not for use in production runtimes.
+#[cfg(feature = "std")]
 pub mod testing {
 
     use super::*;
 
     /// A testing verifier that passes (with zero priority) or not depending on
     /// the boolean value enclosed.
-    #[derive(Encode, Decode, Debug, Clone, PartialEq, Eq)]
+    #[derive(Serialize, Deserialize, Encode, Decode, Debug, Clone, PartialEq, Eq)]
     pub struct TestVerifier {
         /// Whether the verifier should pass.
         pub verifies: bool,

--- a/tuxedo-core/src/verifier.rs
+++ b/tuxedo-core/src/verifier.rs
@@ -7,9 +7,9 @@ use sp_std::fmt::Debug;
 
 use crate::dynamic_typing::DynamicallyTypedData;
 use parity_scale_codec::{Decode, Encode};
-use sp_runtime::transaction_validity::TransactionPriority;
 #[cfg(feature = "std")]
 use serde::{Deserialize, Serialize};
+use sp_runtime::transaction_validity::TransactionPriority;
 
 /// A single verifier that a transaction can choose to call. Verifies whether the input
 /// and output data from a transaction meets the codified constraints.
@@ -28,7 +28,6 @@ pub trait Verifier: Debug + Encode + Decode + Clone {
         output_data: &[DynamicallyTypedData],
     ) -> Result<TransactionPriority, Self::Error>;
 }
-
 
 /// Simple verifier for use in unit tests. Not for use in production runtimes.
 #[cfg(feature = "std")]
@@ -62,13 +61,13 @@ pub mod testing {
 
     #[test]
     fn test_verifier_passes() {
-        let result = TestVerifier{verifies: true}.verify(&[], &[]);
+        let result = TestVerifier { verifies: true }.verify(&[], &[]);
         assert_eq!(result, Ok(0));
     }
 
     #[test]
     fn test_verifier_fails() {
-        let result = TestVerifier{verifies: false}.verify(&[], &[]);
+        let result = TestVerifier { verifies: false }.verify(&[], &[]);
         assert_eq!(result, Err(()));
     }
 }

--- a/tuxedo-core/src/verifier.rs
+++ b/tuxedo-core/src/verifier.rs
@@ -34,7 +34,7 @@ pub mod testing {
     use super::*;
 
     /// A testing verifier that verifies everything.
-    #[derive(Encode, Decode, Debug, Clone)]
+    #[derive(Encode, Decode, Debug, Clone, PartialEq, Eq)]
     pub struct AlwaysVerifies;
 
     impl Verifier for AlwaysVerifies {
@@ -50,7 +50,7 @@ pub mod testing {
     }
 
     /// A testing verifier that verifies nothing.
-    #[derive(Encode, Decode, Debug, Clone)]
+    #[derive(Encode, Decode, Debug, Clone, PartialEq, Eq)]
     pub struct NeverVerifies;
 
     impl Verifier for NeverVerifies {

--- a/tuxedo-core/src/verifier.rs
+++ b/tuxedo-core/src/verifier.rs
@@ -27,17 +27,41 @@ pub trait Verifier: Debug + Encode + Decode + Clone {
     ) -> Result<TransactionPriority, Self::Error>;
 }
 
-// A trivial verifier that verifies everything. Not practical. More for testing
-// and for the sake of making things compile before I get around to writing the
-// amoeba nd PoE verifiers
-impl Verifier for () {
-    type Error = ();
 
-    fn verify(
-        &self,
-        _input_data: &[DynamicallyTypedData],
-        _output_data: &[DynamicallyTypedData],
-    ) -> Result<TransactionPriority, ()> {
-        Ok(0)
+/// Simple verifiers for use in unit tests. Not for use in production runtimes.
+pub mod testing {
+
+    use super::*;
+
+    /// A testing verifier that verifies everything.
+    #[derive(Encode, Decode, Debug, Clone)]
+    pub struct AlwaysVerifies;
+
+    impl Verifier for AlwaysVerifies {
+        type Error = ();
+
+        fn verify(
+            &self,
+            _input_data: &[DynamicallyTypedData],
+            _output_data: &[DynamicallyTypedData],
+        ) -> Result<TransactionPriority, ()> {
+            Ok(0)
+        }
+    }
+
+    /// A testing verifier that verifies nothing.
+    #[derive(Encode, Decode, Debug, Clone)]
+    pub struct NeverVerifies;
+
+    impl Verifier for NeverVerifies {
+        type Error = ();
+
+        fn verify(
+            &self,
+            _input_data: &[DynamicallyTypedData],
+            _output_data: &[DynamicallyTypedData],
+        ) -> Result<TransactionPriority, ()> {
+            Err(())
+        }
     }
 }


### PR DESCRIPTION
This PR adds significant test coverage to the `tuxedo-core` crate.

I hope to achieve 100% according to [cargo tarpaulin](https://lib.rs/crates/cargo-tarpaulin), but I'm not sure how practical that is. In any case, this will add enough coverage to give tuxedo users peace of mind that the core code is working as expected.