### PR TITLE
Blanket impl for powerful verifier

### DIFF
--- a/tuxedo-core/src/verifier.rs
+++ b/tuxedo-core/src/verifier.rs
@@ -48,8 +48,7 @@ pub trait Verifier: Debug + Encode + Decode + Clone {
 // the executive can always just call the Powerful trait.
 impl<T: SimpleVerifier> Verifier for T {
 
-    // When using the blanket implementation, we directly return a UtxoError here
-    // So that we have access to the `RedeemerError` variant
+    // Use the same error type used in the simple implementation.
     type Error = <T as SimpleVerifier>::Error;
 
     fn verify<R: Redeemer>(

--- a/tuxedo-core/src/verifier.rs
+++ b/tuxedo-core/src/verifier.rs
@@ -3,7 +3,7 @@
 //!  do not typically calculate the correct final state, but rather determine whether the
 //! proposed final state (as specified by the output set) meets the necessary constraints.
 
-use sp_std::fmt::Debug;
+use sp_std::{fmt::Debug, vec::Vec};
 
 use crate::{
     Redeemer,
@@ -38,9 +38,41 @@ pub trait Verifier: Debug + Encode + Decode + Clone {
     /// The actual verification logic
     fn verify<R: Redeemer>(
         &self,
-        inputs: &[Input],
+        inputs: &[Output<R>],
         outputs: &[Output<R>],
     ) -> Result<TransactionPriority, Self::Error>;
+}
+
+// This blanket implementation makes it so that any type that chooses to
+// implement the Simple trait also implements the Powerful trait. This way
+// the executive can always just call the Powerful trait.
+impl<T: SimpleVerifier> Verifier for T {
+
+    // When using the blanket implementation, we directly return a UtxoError here
+    // So that we have access to the `RedeemerError` variant
+    type Error = <T as SimpleVerifier>::Error;
+
+    fn verify<R: Redeemer>(
+        &self,
+        inputs: &[Output<R>],
+        outputs: &[Output<R>],
+    ) -> Result<TransactionPriority, Self::Error> {
+
+        // Extract the input data
+        let input_data: Vec<DynamicallyTypedData> = inputs
+            .iter()
+            .map(|o| o.payload.clone())
+            .collect();
+
+        // Extract the output data
+        let output_data: Vec<DynamicallyTypedData> = outputs
+            .iter()
+            .map(|o| o.payload.clone())
+            .collect();
+
+        // Call the simple verifier
+        SimpleVerifier::verify(self, &input_data, &output_data)
+    }
 }
 
 // impl PowerfulVerifier for () {

--- a/tuxedo-template-runtime/src/amoeba.rs
+++ b/tuxedo-template-runtime/src/amoeba.rs
@@ -16,7 +16,7 @@ use sp_std::vec::Vec;
 use tuxedo_core::{
     types::{Input, Output},
     dynamic_typing::{DynamicallyTypedData, UtxoData},
-    ensure, Verifier, SimpleVerifier, utxo_set::TransparentUtxoSet, Redeemer,
+    ensure, SimpleVerifier, utxo_set::TransparentUtxoSet, Redeemer,
 };
 
 /// An amoeba tracked by our simple Amoeba APP

--- a/tuxedo-template-runtime/src/amoeba.rs
+++ b/tuxedo-template-runtime/src/amoeba.rs
@@ -129,31 +129,6 @@ impl SimpleVerifier for AmoebaMitosis {
     }
 }
 
-impl Verifier for AmoebaMitosis {
-    type Error = VerifierError;
-
-    fn verify<R: Redeemer>(
-        &self,
-        inputs: &[Input],
-        outputs: &[Output<R>],
-    ) -> Result<TransactionPriority, Self::Error> {
-        let input_data: Vec<DynamicallyTypedData> = inputs
-            .iter()
-            .map(|i| {
-                TransparentUtxoSet::<R>::peek_utxo(&i.output_ref)
-                    .expect("We just checked that all inputs were present.")
-                    .payload
-            })
-            .collect();
-        let output_data: Vec<DynamicallyTypedData> = outputs
-            .iter()
-            .map(|o| o.payload.clone())
-            .collect();
-
-        <AmoebaMitosis as SimpleVerifier>::verify(self, &input_data, &output_data)
-    }
-}
-
 /// A verifier for simple death of an amoeba.
 ///
 /// Any amoeba can be killed by providing it as the sole input to this verifier. No
@@ -190,31 +165,6 @@ impl SimpleVerifier for AmoebaDeath {
     }
 }
 
-impl Verifier for AmoebaDeath {
-    type Error = VerifierError;
-
-    fn verify<R: Redeemer>(
-        &self,
-        inputs: &[Input],
-        outputs: &[Output<R>],
-    ) -> Result<TransactionPriority, Self::Error> {
-        let input_data: Vec<DynamicallyTypedData> = inputs
-            .iter()
-            .map(|i| {
-                TransparentUtxoSet::<R>::peek_utxo(&i.output_ref)
-                    .expect("We just checked that all inputs were present.")
-                    .payload
-            })
-            .collect();
-        let output_data: Vec<DynamicallyTypedData> = outputs
-            .iter()
-            .map(|o| o.payload.clone())
-            .collect();
-
-        <AmoebaDeath as SimpleVerifier>::verify(self, &input_data, &output_data)
-    }
-}
-
 /// A verifier for simple creation of an amoeba.
 ///
 /// A new amoeba can be created by providing it as the sole output to this verifier. No
@@ -248,31 +198,6 @@ impl SimpleVerifier for AmoebaCreation {
         ensure!(input_data.is_empty(), VerifierError::CreationMayNotConsume);
 
         Ok(0)
-    }
-}
-
-impl Verifier for AmoebaCreation {
-    type Error = VerifierError;
-
-    fn verify<R: Redeemer>(
-        &self,
-        inputs: &[Input],
-        outputs: &[Output<R>],
-    ) -> Result<TransactionPriority, Self::Error> {
-        let input_data: Vec<DynamicallyTypedData> = inputs
-            .iter()
-            .map(|i| {
-                TransparentUtxoSet::<R>::peek_utxo(&i.output_ref)
-                    .expect("We just checked that all inputs were present.")
-                    .payload
-            })
-            .collect();
-        let output_data: Vec<DynamicallyTypedData> = outputs
-            .iter()
-            .map(|o| o.payload.clone())
-            .collect();
-
-        <AmoebaCreation as SimpleVerifier>::verify(self, &input_data, &output_data)
     }
 }
 

--- a/tuxedo-template-runtime/src/kitties.rs
+++ b/tuxedo-template-runtime/src/kitties.rs
@@ -380,32 +380,6 @@ impl SimpleVerifier for FreeKittyVerifier {
     }
 }
 
-// 5.) Eventually Abstract this with derive macro
-impl Verifier for FreeKittyVerifier {
-    type Error = VerifierError;
-
-    fn verify<R: Redeemer>(
-        &self,
-        inputs: &[Input],
-        outputs: &[Output<R>],
-    ) -> Result<TransactionPriority, Self::Error> {
-        let input_data: Vec<DynamicallyTypedData> = inputs
-            .iter()
-            .map(|i| {
-                TransparentUtxoSet::<R>::peek_utxo(&i.output_ref)
-                    .expect("We just checked that all inputs were present.")
-                    .payload
-            })
-            .collect();
-        let output_data: Vec<DynamicallyTypedData> = outputs
-            .iter()
-            .map(|o| o.payload.clone())
-            .collect();
-
-        <FreeKittyVerifier as SimpleVerifier>::verify(self, &input_data, &output_data)
-    }
-}
-
 #[cfg(test)]
 mod test {
     use super::*;

--- a/tuxedo-template-runtime/src/lib.rs
+++ b/tuxedo-template-runtime/src/lib.rs
@@ -296,7 +296,7 @@ impl Verifier for OuterVerifier {
 
     fn verify<R: Redeemer>(
         &self,
-        inputs: &[Input],
+        inputs: &[Output<R>],
         outputs: &[Output<R>],
     ) -> Result<TransactionPriority, OuterVerifierError> {
         Ok(match self {

--- a/tuxedo-template-runtime/src/money.rs
+++ b/tuxedo-template-runtime/src/money.rs
@@ -154,31 +154,6 @@ impl SimpleVerifier for MoneyVerifier {
     }
 }
 
-impl Verifier for MoneyVerifier {
-    type Error = VerifierError;
-
-    fn verify<R: Redeemer>(
-        &self,
-        inputs: &[Input],
-        outputs: &[Output<R>],
-    ) -> Result<TransactionPriority, Self::Error> {
-        let input_data: Vec<DynamicallyTypedData> = inputs
-            .iter()
-            .map(|i| {
-                TransparentUtxoSet::<R>::peek_utxo(&i.output_ref)
-                    .expect("We just checked that all inputs were present.")
-                    .payload
-            })
-            .collect();
-        let output_data: Vec<DynamicallyTypedData> = outputs
-            .iter()
-            .map(|o| o.payload.clone())
-            .collect();
-
-        <MoneyVerifier as SimpleVerifier>::verify(self, &input_data, &output_data)
-    }
-}
-
 /// Unit tests for the Money piece
 #[cfg(test)]
 mod test {

--- a/tuxedo-template-runtime/src/money.rs
+++ b/tuxedo-template-runtime/src/money.rs
@@ -9,7 +9,7 @@ use sp_std::prelude::*;
 use tuxedo_core::{
     types::{Input, Output},
     dynamic_typing::{DynamicallyTypedData, UtxoData}, utxo_set::TransparentUtxoSet,
-    ensure, Verifier, SimpleVerifier, Redeemer,
+    ensure, SimpleVerifier, Redeemer,
 };
 
 // use log::info;

--- a/tuxedo-template-runtime/src/poe.rs
+++ b/tuxedo-template-runtime/src/poe.rs
@@ -111,31 +111,6 @@ impl SimpleVerifier for PoeClaim {
     }
 }
 
-impl Verifier for PoeClaim {
-    type Error = VerifierError;
-
-    fn verify<R: Redeemer>(
-        &self,
-        inputs: &[Input],
-        outputs: &[Output<R>],
-    ) -> Result<TransactionPriority, Self::Error> {
-        let input_data: Vec<DynamicallyTypedData> = inputs
-            .iter()
-            .map(|i| {
-                TransparentUtxoSet::<R>::peek_utxo(&i.output_ref)
-                    .expect("We just checked that all inputs were present.")
-                    .payload
-            })
-            .collect();
-        let output_data: Vec<DynamicallyTypedData> = outputs
-            .iter()
-            .map(|o| o.payload.clone())
-            .collect();
-
-        <PoeClaim as SimpleVerifier>::verify(self, &input_data, &output_data)
-    }
-}
-
 /// A verifier to revoke claims.
 ///
 /// Like the creation verifier, this allows batch revocation.
@@ -165,31 +140,6 @@ impl SimpleVerifier for PoeRevoke {
         }
 
         Ok(0)
-    }
-}
-
-impl Verifier for PoeRevoke {
-    type Error = VerifierError;
-
-    fn verify<R: Redeemer>(
-        &self,
-        inputs: &[Input],
-        outputs: &[Output<R>],
-    ) -> Result<TransactionPriority, Self::Error> {
-        let input_data: Vec<DynamicallyTypedData> = inputs
-            .iter()
-            .map(|i| {
-                TransparentUtxoSet::<R>::peek_utxo(&i.output_ref)
-                    .expect("We just checked that all inputs were present.")
-                    .payload
-            })
-            .collect();
-        let output_data: Vec<DynamicallyTypedData> = outputs
-            .iter()
-            .map(|o| o.payload.clone())
-            .collect();
-
-        <PoeRevoke as SimpleVerifier>::verify(self, &input_data, &output_data)
     }
 }
 
@@ -228,31 +178,6 @@ impl SimpleVerifier for PoeDispute {
         // Make sure that all other claims have block heights strictly greater than the winner.
 
         //TODO what to do about the redeemers on those losing claims.
-    }
-}
-
-impl Verifier for PoeDispute {
-    type Error = VerifierError;
-
-    fn verify<R: Redeemer>(
-        &self,
-        inputs: &[Input],
-        outputs: &[Output<R>],
-    ) -> Result<TransactionPriority, Self::Error> {
-        let input_data: Vec<DynamicallyTypedData> = inputs
-            .iter()
-            .map(|i| {
-                TransparentUtxoSet::<R>::peek_utxo(&i.output_ref)
-                    .expect("We just checked that all inputs were present.")
-                    .payload
-            })
-            .collect();
-        let output_data: Vec<DynamicallyTypedData> = outputs
-            .iter()
-            .map(|o| o.payload.clone())
-            .collect();
-
-        <PoeDispute as SimpleVerifier>::verify(self, &input_data, &output_data)
     }
 }
 

--- a/tuxedo-template-runtime/src/runtime_upgrade.rs
+++ b/tuxedo-template-runtime/src/runtime_upgrade.rs
@@ -108,28 +108,3 @@ impl SimpleVerifier for RuntimeUpgrade {
         Ok(0)
     }
 }
-
-impl Verifier for RuntimeUpgrade {
-    type Error = VerifierError;
-
-    fn verify<R: Redeemer>(
-        &self,
-        inputs: &[Input],
-        outputs: &[Output<R>],
-    ) -> Result<TransactionPriority, Self::Error> {
-        let input_data: Vec<DynamicallyTypedData> = inputs
-            .iter()
-            .map(|i| {
-                TransparentUtxoSet::<R>::peek_utxo(&i.output_ref)
-                    .expect("We just checked that all inputs were present.")
-                    .payload
-            })
-            .collect();
-        let output_data: Vec<DynamicallyTypedData> = outputs
-            .iter()
-            .map(|o| o.payload.clone())
-            .collect();
-
-        <RuntimeUpgrade as SimpleVerifier>::verify(self, &input_data, &output_data)
-    }
-}


### PR DESCRIPTION
:warning: This PR is not against `main`; it is against #41 

**Main Change**

The main thing this PR does is add a blanket implementation so that any type that implements the `SimpleVerifier` automatically implements the more powerful `Verifier`. Doing it with a blanket impl avoids the need for a macro.

**Secondary Change**

This slightly changes the signature for the new powerful `Verifier` trait so that it doesn't take inputs, but rather the `Outputs` that are being consumed by the inputs. This allows trait implementers (aka piece developers) not to worry about fetching the Outputs from storage.