### PR TITLE
Better branding in command.rs

### DIFF
--- a/node/src/command.rs
+++ b/node/src/command.rs
@@ -9,7 +9,7 @@ use sc_service::PartialComponents;
 
 impl SubstrateCli for Cli {
     fn impl_name() -> String {
-        "Substrate Node".into()
+        "Tuxedo Template Node".into()
     }
 
     fn impl_version() -> String {
@@ -25,11 +25,11 @@ impl SubstrateCli for Cli {
     }
 
     fn support_url() -> String {
-        "support.anonymous.an".into()
+        "https://github.com/Off-Narrative-Labs/Tuxedo/issues".into()
     }
 
     fn copyright_start_year() -> i32 {
-        2017
+        2023
     }
 
     fn load_spec(&self, id: &str) -> Result<Box<dyn sc_service::ChainSpec>, String> {


### PR DESCRIPTION
Solves #21.

Updates the copyright start year, the issue queue url and the name of the node.