### PR TITLE
Implement Peeks

### DIFF
--- a/tuxedo-core/src/executive.rs
+++ b/tuxedo-core/src/executive.rs
@@ -542,6 +542,11 @@ mod tests {
     }
 
     #[test]
+    fn validate_with_peek_works() {
+        todo!()
+    }
+
+    #[test]
     fn validate_with_output_works() {
         ExternalityBuilder::default().build().execute_with(|| {
             let output = Output {
@@ -594,6 +599,11 @@ mod tests {
     }
 
     #[test]
+    fn validate_with_missing_peek_works() {
+        todo!()
+    }
+
+    #[test]
     fn validate_with_duplicate_input_fails() {
         ExternalityBuilder::default()
             .with_utxo(0, 0, Bogus, false)
@@ -615,6 +625,11 @@ mod tests {
 
                 assert_eq!(result, Err(UtxoError::DuplicateInput));
             });
+    }
+
+    #[test]
+    fn validate_with_duplicate_peek_works() {
+        todo!()
     }
 
     #[test]
@@ -721,6 +736,11 @@ mod tests {
 
             assert_eq!(vt, Err(UtxoError::MissingInput));
         });
+    }
+
+    #[test]
+    fn apply_with_missing_peek_fails() {
+        todo!()
     }
 
     #[test]

--- a/tuxedo-core/src/types.rs
+++ b/tuxedo-core/src/types.rs
@@ -41,9 +41,13 @@ pub struct OutputRef {
 )]
 #[derive(Encode, Decode, Debug, PartialEq, Eq, Clone)]
 pub struct Transaction<V, C> {
+    /// Existing state to be read and consumed from storage
     pub inputs: Vec<Input>,
-    //Todo peeks: Vec<Input>,
+    /// Existing state to be read, but not consumed, from storage
+    pub peeks: Vec<OutputRef>,
+    /// New state to be placed into storage
     pub outputs: Vec<Output<V>>,
+    /// Which piece of constraint checking logic is used to determine whether this transaction is valid
     pub checker: C,
 }
 
@@ -126,6 +130,7 @@ pub mod tests {
         let checker = TestConstraintChecker { checks: true };
         let tx: Transaction<UpForGrabs, TestConstraintChecker> = Transaction {
             inputs: Vec::new(),
+            peeks: Vec::new(),
             outputs: Vec::new(),
             checker,
         };
@@ -140,6 +145,7 @@ pub mod tests {
         let checker = TestConstraintChecker { checks: true };
         let tx: Transaction<UpForGrabs, TestConstraintChecker> = Transaction {
             inputs: Vec::new(),
+            peeks: Vec::new(),
             outputs: Vec::new(),
             checker,
         };

--- a/tuxedo-template-runtime/src/amoeba.rs
+++ b/tuxedo-template-runtime/src/amoeba.rs
@@ -90,6 +90,7 @@ impl SimpleConstraintChecker for AmoebaMitosis {
     fn check(
         &self,
         input_data: &[DynamicallyTypedData],
+        _peeks:  &[DynamicallyTypedData],
         output_data: &[DynamicallyTypedData],
     ) -> Result<TransactionPriority, ConstraintCheckerError> {
         // Make sure there is exactly one mother.
@@ -151,6 +152,7 @@ impl SimpleConstraintChecker for AmoebaDeath {
     fn check(
         &self,
         input_data: &[DynamicallyTypedData],
+        _peeks:  &[DynamicallyTypedData],
         output_data: &[DynamicallyTypedData],
     ) -> Result<TransactionPriority, Self::Error> {
         // Make sure there is a single victim
@@ -193,6 +195,7 @@ impl SimpleConstraintChecker for AmoebaCreation {
     fn check(
         &self,
         input_data: &[DynamicallyTypedData],
+        _peeks:  &[DynamicallyTypedData],
         output_data: &[DynamicallyTypedData],
     ) -> Result<TransactionPriority, Self::Error> {
         // Make sure there is a single created amoeba

--- a/tuxedo-template-runtime/src/kitties.rs
+++ b/tuxedo-template-runtime/src/kitties.rs
@@ -389,6 +389,7 @@ impl SimpleConstraintChecker for FreeKittyConstraintChecker {
     fn check(
         &self,
         input_data: &[DynamicallyTypedData],
+        _peeks:  &[DynamicallyTypedData],
         output_data: &[DynamicallyTypedData],
     ) -> Result<TransactionPriority, Self::Error> {
         // Input must be a Mom and a Dad

--- a/tuxedo-template-runtime/src/lib.rs
+++ b/tuxedo-template-runtime/src/lib.rs
@@ -297,18 +297,19 @@ impl ConstraintChecker for OuterConstraintChecker {
     fn check<V: Verifier>(
         &self,
         inputs: &[Output<V>],
+        peeks: &[Output<V>],
         outputs: &[Output<V>],
     ) -> Result<TransactionPriority, OuterConstraintCheckerError> {
         Ok(match self {
-            Self::Money(money) => money.check(inputs, outputs)?,
-            Self::FreeKittyConstraintChecker(free_breed) => free_breed.check(inputs, outputs)?,
-            Self::AmoebaMitosis(amoeba_mitosis) => amoeba_mitosis.check(inputs, outputs)?,
-            Self::AmoebaDeath(amoeba_death) => amoeba_death.check(inputs, outputs)?,
-            Self::AmoebaCreation(amoeba_creation) => amoeba_creation.check(inputs, outputs)?,
-            Self::PoeClaim(poe_claim) => poe_claim.check(inputs, outputs)?,
-            Self::PoeRevoke(poe_revoke) => poe_revoke.check(inputs, outputs)?,
-            Self::PoeDispute(poe_dispute) => poe_dispute.check(inputs, outputs)?,
-            Self::RuntimeUpgrade(runtime_upgrade) => runtime_upgrade.check(inputs, outputs)?,
+            Self::Money(money) => money.check(inputs, peeks, outputs)?,
+            Self::FreeKittyConstraintChecker(free_breed) => free_breed.check(inputs, peeks, outputs)?,
+            Self::AmoebaMitosis(amoeba_mitosis) => amoeba_mitosis.check(inputs, peeks, outputs)?,
+            Self::AmoebaDeath(amoeba_death) => amoeba_death.check(inputs, peeks, outputs)?,
+            Self::AmoebaCreation(amoeba_creation) => amoeba_creation.check(inputs, peeks, outputs)?,
+            Self::PoeClaim(poe_claim) => poe_claim.check(inputs, peeks, outputs)?,
+            Self::PoeRevoke(poe_revoke) => poe_revoke.check(inputs, peeks, outputs)?,
+            Self::PoeDispute(poe_dispute) => poe_dispute.check(inputs, peeks, outputs)?,
+            Self::RuntimeUpgrade(runtime_upgrade) => runtime_upgrade.check(inputs, peeks, outputs)?,
         })
     }
 }

--- a/tuxedo-template-runtime/src/money.rs
+++ b/tuxedo-template-runtime/src/money.rs
@@ -84,6 +84,7 @@ impl SimpleConstraintChecker for MoneyConstraintChecker {
     fn check(
         &self,
         input_data: &[DynamicallyTypedData],
+        _peeks:  &[DynamicallyTypedData],
         output_data: &[DynamicallyTypedData],
     ) -> Result<TransactionPriority, Self::Error> {
         match &self {

--- a/tuxedo-template-runtime/src/poe.rs
+++ b/tuxedo-template-runtime/src/poe.rs
@@ -83,6 +83,7 @@ impl SimpleConstraintChecker for PoeClaim {
     fn check(
         &self,
         input_data: &[DynamicallyTypedData],
+        _peeks:  &[DynamicallyTypedData],
         output_data: &[DynamicallyTypedData],
     ) -> Result<TransactionPriority, Self::Error> {
         // Make sure there are no inputs
@@ -129,6 +130,7 @@ impl SimpleConstraintChecker for PoeRevoke {
     fn check(
         &self,
         input_data: &[DynamicallyTypedData],
+        _peeks:  &[DynamicallyTypedData],
         output_data: &[DynamicallyTypedData],
     ) -> Result<TransactionPriority, Self::Error> {
         // Make sure there are no outputs
@@ -171,6 +173,7 @@ impl SimpleConstraintChecker for PoeDispute {
     fn check(
         &self,
         _input_data: &[DynamicallyTypedData],
+        _peeks:  &[DynamicallyTypedData],
         _output_data: &[DynamicallyTypedData],
     ) -> Result<TransactionPriority, Self::Error> {
         todo!("implement this once we have at least peeks and maybe evictions")

--- a/tuxedo-template-runtime/src/runtime_upgrade.rs
+++ b/tuxedo-template-runtime/src/runtime_upgrade.rs
@@ -80,6 +80,7 @@ impl SimpleConstraintChecker for RuntimeUpgrade {
     fn check(
         &self,
         input_data: &[DynamicallyTypedData],
+        _peeks:  &[DynamicallyTypedData],
         output_data: &[DynamicallyTypedData],
     ) -> Result<TransactionPriority, Self::Error> {
         // Make sure there is a single input that matches the hash of the previous runtime logic


### PR DESCRIPTION
This PR adds the peek functionality for reading state without consuming it as described in the original grant proposal.

This will help facilitate concurrency down the road. Even before that, it makes it nice that you can read state without re-writing it and therefore changing its `OutputRef`.