### PR TITLE
Verifier creation time checks

### DIFF
--- a/tuxedo-core/src/executive.rs
+++ b/tuxedo-core/src/executive.rs
@@ -79,6 +79,7 @@ impl<B: BlockT<Extrinsic = Transaction<V, C>>, V: Verifier, C: ConstraintChecker
         }
 
         // Make sure no outputs already exist in storage
+        // and that the new outputs have valid verifiers
         let tx_hash = BlakeTwo256::hash_of(&transaction.encode());
         for index in 0..transaction.outputs.len() {
             let output_ref = OutputRef {
@@ -95,6 +96,12 @@ impl<B: BlockT<Extrinsic = Transaction<V, C>>, V: Verifier, C: ConstraintChecker
             ensure!(
                 TransparentUtxoSet::<V>::peek_utxo(&output_ref).is_none(),
                 UtxoError::PreExistingOutput
+            );
+
+            let output = transaction.outputs[index];
+            ensure!(
+                output.verifier.ensure_verifier_data_is_valid(),
+                UtxoError::InvalidVerifierIncludedInOutput
             );
         }
 

--- a/tuxedo-core/src/executive.rs
+++ b/tuxedo-core/src/executive.rs
@@ -98,9 +98,8 @@ impl<B: BlockT<Extrinsic = Transaction<V, C>>, V: Verifier, C: ConstraintChecker
                 UtxoError::PreExistingOutput
             );
 
-            let output = transaction.outputs[index];
             ensure!(
-                output.verifier.ensure_verifier_data_is_valid(),
+                transaction.outputs[index].verifier.ensure_verifier_data_is_valid(),
                 UtxoError::InvalidVerifierIncludedInOutput
             );
         }

--- a/tuxedo-core/src/types.rs
+++ b/tuxedo-core/src/types.rs
@@ -95,6 +95,8 @@ pub enum UtxoError<ConstraintCheckerError> {
     VerifierError,
     /// One or more of the inputs required by this transaction is not present in the UTXO set
     MissingInput,
+    /// One or more of the Outputs contains a verifier that is not self consistent
+    InvalidVerifierIncludedInOutput,
 }
 
 /// The Result of dispatching a UTXO transaction.

--- a/tuxedo-core/src/verifier.rs
+++ b/tuxedo-core/src/verifier.rs
@@ -17,7 +17,15 @@ use sp_std::fmt::Debug;
 /// be applied to the transaction as a whole. Nonetheless, in order to avoid malleability, we
 /// we take the entire stripped and serialized transaction as a parameter.
 pub trait Verifier: Debug + Encode + Decode + Clone {
+    /// Perform the actual verification and determine whether the output can be spent.
     fn verify(&self, simplified_tx: &[u8], redeemer: &[u8]) -> bool;
+
+    /// This method is run at the time when new UTXOs are being added to the state.
+    /// This allows the verifier to enforce constraints about the data provided.
+    /// For example, in a multisig, it can enforce that there are no duplicate signatories.
+    fn ensure_verifier_data_is_valid(&self) -> bool {
+        true
+    }
 }
 
 /// A typical verifier that checks an sr25519 signature


### PR DESCRIPTION
This is a braindump of an idea that allows verifiers to enforce constraints about their data at the time they are being created. I'm not sure if it is a good idea.

On the one hand, this prevents users from accidentally locking their funds or other assets forever by accidentally submitting invalid verifiers (eg a multisig with duplicated signatories).

On the other hand, the adds more checking logic on chain for all nodes to execute, and it only benefits the user who may have carelessly submitted an invalid verifier. When framed this way, I'm inclined to think that providing an invalid verifier is just a generalization on sending funds to the wrong account. In that case, it is culturally well established that this is the user's problem.