### PR TITLE
Implement Evictions

### DIFF
--- a/tuxedo-core/src/constraint_checker.rs
+++ b/tuxedo-core/src/constraint_checker.rs
@@ -75,7 +75,7 @@ impl<T: SimpleConstraintChecker> ConstraintChecker for T {
         // Extract the peek data
         let peek_data: Vec<DynamicallyTypedData> =
             peeks.iter().map(|o| o.payload.clone()).collect();
-        
+
         // Extract the eviction data
         let eviction_data: Vec<DynamicallyTypedData> =
             evictions.iter().map(|o| o.payload.clone()).collect();
@@ -122,15 +122,25 @@ pub mod testing {
 
     #[test]
     fn test_checker_passes() {
-        let result =
-            SimpleConstraintChecker::check(&TestConstraintChecker { checks: true }, &[], &[], &[], &[]);
+        let result = SimpleConstraintChecker::check(
+            &TestConstraintChecker { checks: true },
+            &[],
+            &[],
+            &[],
+            &[],
+        );
         assert_eq!(result, Ok(0));
     }
 
     #[test]
     fn test_checker_fails() {
-        let result =
-            SimpleConstraintChecker::check(&TestConstraintChecker { checks: false }, &[], &[], &[], &[]);
+        let result = SimpleConstraintChecker::check(
+            &TestConstraintChecker { checks: false },
+            &[],
+            &[],
+            &[],
+            &[],
+        );
         assert_eq!(result, Err(()));
     }
 }

--- a/tuxedo-core/src/executive.rs
+++ b/tuxedo-core/src/executive.rs
@@ -149,7 +149,12 @@ impl<B: BlockT<Extrinsic = Transaction<V, C>>, V: Verifier, C: ConstraintChecker
         // Call the constraint checker
         transaction
             .checker
-            .check(&input_utxos, &peek_utxos, &eviction_utxos, &transaction.outputs)
+            .check(
+                &input_utxos,
+                &peek_utxos,
+                &eviction_utxos,
+                &transaction.outputs,
+            )
             .map_err(UtxoError::ConstraintCheckerError)?;
 
         // Return the valid transaction

--- a/tuxedo-core/src/types.rs
+++ b/tuxedo-core/src/types.rs
@@ -45,6 +45,10 @@ pub struct Transaction<V, C> {
     pub inputs: Vec<Input>,
     /// Existing state to be read, but not consumed, from storage
     pub peeks: Vec<OutputRef>,
+    /// Existing state to be read and forcefully consumed from storage
+    /// Evictions are consumed without requiring a redeemer that satisfies the verifier
+    /// Evictions are used for cleaning up old or unnecessary state
+    pub evictions: Vec<OutputRef>,
     /// New state to be placed into storage
     pub outputs: Vec<Output<V>>,
     /// Which piece of constraint checking logic is used to determine whether this transaction is valid
@@ -131,6 +135,7 @@ pub mod tests {
         let tx: Transaction<UpForGrabs, TestConstraintChecker> = Transaction {
             inputs: Vec::new(),
             peeks: Vec::new(),
+            evictions: Vec::new(),
             outputs: Vec::new(),
             checker,
         };
@@ -146,6 +151,7 @@ pub mod tests {
         let tx: Transaction<UpForGrabs, TestConstraintChecker> = Transaction {
             inputs: Vec::new(),
             peeks: Vec::new(),
+            evictions: Vec::new(),
             outputs: Vec::new(),
             checker,
         };

--- a/tuxedo-template-runtime/src/amoeba.rs
+++ b/tuxedo-template-runtime/src/amoeba.rs
@@ -90,6 +90,7 @@ impl SimpleConstraintChecker for AmoebaMitosis {
     fn check(
         &self,
         input_data: &[DynamicallyTypedData],
+        _evictions: &[DynamicallyTypedData],
         _peeks: &[DynamicallyTypedData],
         output_data: &[DynamicallyTypedData],
     ) -> Result<TransactionPriority, ConstraintCheckerError> {
@@ -153,6 +154,7 @@ impl SimpleConstraintChecker for AmoebaDeath {
         &self,
         input_data: &[DynamicallyTypedData],
         _peeks: &[DynamicallyTypedData],
+        _evictions: &[DynamicallyTypedData],
         output_data: &[DynamicallyTypedData],
     ) -> Result<TransactionPriority, Self::Error> {
         // Make sure there is a single victim
@@ -196,6 +198,7 @@ impl SimpleConstraintChecker for AmoebaCreation {
         &self,
         input_data: &[DynamicallyTypedData],
         _peeks: &[DynamicallyTypedData],
+        _evictions: &[DynamicallyTypedData],
         output_data: &[DynamicallyTypedData],
     ) -> Result<TransactionPriority, Self::Error> {
         // Make sure there is a single created amoeba
@@ -238,7 +241,7 @@ mod test {
         let input_data = Vec::new();
         let output_data = vec![to_spawn.into()];
 
-        assert_eq!(AmoebaCreation.check(&input_data, &[], &output_data), Ok(0),);
+        assert_eq!(AmoebaCreation.check(&input_data, &[], &[], &output_data), Ok(0),);
     }
 
     #[test]
@@ -251,7 +254,7 @@ mod test {
         let output_data = vec![to_spawn.into()];
 
         assert_eq!(
-            AmoebaCreation.check(&input_data, &[], &output_data),
+            AmoebaCreation.check(&input_data, &[], &[], &output_data),
             Err(ConstraintCheckerError::WrongGeneration),
         );
     }
@@ -266,7 +269,7 @@ mod test {
         let output_data = vec![example.into()];
 
         assert_eq!(
-            AmoebaCreation.check(&input_data, &[], &output_data),
+            AmoebaCreation.check(&input_data, &[], &[], &output_data),
             Err(ConstraintCheckerError::CreationMayNotConsume),
         );
     }
@@ -277,7 +280,7 @@ mod test {
         let output_data = vec![Bogus.into()];
 
         assert_eq!(
-            AmoebaCreation.check(&input_data, &[], &output_data),
+            AmoebaCreation.check(&input_data, &[], &[], &output_data),
             Err(ConstraintCheckerError::BadlyTypedOutput),
         );
     }
@@ -292,7 +295,7 @@ mod test {
         let output_data = vec![to_spawn.clone().into(), to_spawn.into()];
 
         assert_eq!(
-            AmoebaCreation.check(&input_data, &[], &output_data),
+            AmoebaCreation.check(&input_data, &[], &[], &output_data),
             Err(ConstraintCheckerError::CreatedTooMany),
         );
     }
@@ -303,7 +306,7 @@ mod test {
         let output_data = Vec::new();
 
         assert_eq!(
-            AmoebaCreation.check(&input_data, &[], &output_data),
+            AmoebaCreation.check(&input_data, &[], &[], &output_data),
             Err(ConstraintCheckerError::CreatedNothing),
         );
     }
@@ -325,7 +328,7 @@ mod test {
         let input_data = vec![mother.into()];
         let output_data = vec![d1.into(), d2.into()];
 
-        assert_eq!(AmoebaMitosis.check(&input_data, &[], &output_data), Ok(0),);
+        assert_eq!(AmoebaMitosis.check(&input_data, &[], &[], &output_data), Ok(0),);
     }
 
     #[test]
@@ -346,7 +349,7 @@ mod test {
         let output_data = vec![d1.into(), d2.into()];
 
         assert_eq!(
-            AmoebaMitosis.check(&input_data, &[], &output_data),
+            AmoebaMitosis.check(&input_data, &[], &[], &output_data),
             Err(ConstraintCheckerError::WrongGeneration),
         );
     }
@@ -366,7 +369,7 @@ mod test {
         let output_data = vec![d1.into(), d2.into()];
 
         assert_eq!(
-            AmoebaMitosis.check(&input_data, &[], &output_data),
+            AmoebaMitosis.check(&input_data, &[], &[], &output_data),
             Err(ConstraintCheckerError::BadlyTypedInput),
         );
     }
@@ -385,7 +388,7 @@ mod test {
         let output_data = vec![d1.into(), d2.into()];
 
         assert_eq!(
-            AmoebaMitosis.check(&input_data, &[], &output_data),
+            AmoebaMitosis.check(&input_data, &[], &[], &output_data),
             Err(ConstraintCheckerError::WrongNumberOfMothers),
         );
     }
@@ -405,7 +408,7 @@ mod test {
         let output_data = vec![d1.into(), d2.into()];
 
         assert_eq!(
-            AmoebaMitosis.check(&input_data, &[], &output_data),
+            AmoebaMitosis.check(&input_data, &[], &[], &output_data),
             Err(ConstraintCheckerError::BadlyTypedOutput),
         );
     }
@@ -425,7 +428,7 @@ mod test {
         let output_data = vec![d1.into()];
 
         assert_eq!(
-            AmoebaMitosis.check(&input_data, &[], &output_data),
+            AmoebaMitosis.check(&input_data, &[], &[], &output_data),
             Err(ConstraintCheckerError::WrongNumberOfDaughters),
         );
     }
@@ -453,7 +456,7 @@ mod test {
         let output_data = vec![d1.into(), d2.into(), d3.into()];
 
         assert_eq!(
-            AmoebaMitosis.check(&input_data, &[], &output_data),
+            AmoebaMitosis.check(&input_data, &[], &[], &output_data),
             Err(ConstraintCheckerError::WrongNumberOfDaughters),
         );
     }
@@ -467,7 +470,7 @@ mod test {
         let input_data = vec![example.into()];
         let output_data = vec![];
 
-        assert_eq!(AmoebaDeath.check(&input_data, &[], &output_data), Ok(0),);
+        assert_eq!(AmoebaDeath.check(&input_data, &[], &[], &output_data), Ok(0),);
     }
 
     #[test]
@@ -476,7 +479,7 @@ mod test {
         let output_data = vec![];
 
         assert_eq!(
-            AmoebaDeath.check(&input_data, &[], &output_data),
+            AmoebaDeath.check(&input_data, &[], &[], &output_data),
             Err(ConstraintCheckerError::NoVictim),
         );
     }
@@ -495,7 +498,7 @@ mod test {
         let output_data = vec![];
 
         assert_eq!(
-            AmoebaDeath.check(&input_data, &[], &output_data),
+            AmoebaDeath.check(&input_data, &[], &[], &output_data),
             Err(ConstraintCheckerError::TooManyVictims),
         );
     }
@@ -510,7 +513,7 @@ mod test {
         let output_data = vec![example.into()];
 
         assert_eq!(
-            AmoebaDeath.check(&input_data, &[], &output_data),
+            AmoebaDeath.check(&input_data, &[], &[], &output_data),
             Err(ConstraintCheckerError::DeathMayNotCreate),
         );
     }
@@ -522,7 +525,7 @@ mod test {
         let output_data = vec![];
 
         assert_eq!(
-            AmoebaDeath.check(&input_data, &[], &output_data),
+            AmoebaDeath.check(&input_data, &[], &[], &output_data),
             Err(ConstraintCheckerError::BadlyTypedInput),
         );
     }

--- a/tuxedo-template-runtime/src/amoeba.rs
+++ b/tuxedo-template-runtime/src/amoeba.rs
@@ -241,7 +241,10 @@ mod test {
         let input_data = Vec::new();
         let output_data = vec![to_spawn.into()];
 
-        assert_eq!(AmoebaCreation.check(&input_data, &[], &[], &output_data), Ok(0),);
+        assert_eq!(
+            AmoebaCreation.check(&input_data, &[], &[], &output_data),
+            Ok(0),
+        );
     }
 
     #[test]
@@ -328,7 +331,10 @@ mod test {
         let input_data = vec![mother.into()];
         let output_data = vec![d1.into(), d2.into()];
 
-        assert_eq!(AmoebaMitosis.check(&input_data, &[], &[], &output_data), Ok(0),);
+        assert_eq!(
+            AmoebaMitosis.check(&input_data, &[], &[], &output_data),
+            Ok(0),
+        );
     }
 
     #[test]
@@ -470,7 +476,10 @@ mod test {
         let input_data = vec![example.into()];
         let output_data = vec![];
 
-        assert_eq!(AmoebaDeath.check(&input_data, &[], &[], &output_data), Ok(0),);
+        assert_eq!(
+            AmoebaDeath.check(&input_data, &[], &[], &output_data),
+            Ok(0),
+        );
     }
 
     #[test]

--- a/tuxedo-template-runtime/src/kitties.rs
+++ b/tuxedo-template-runtime/src/kitties.rs
@@ -390,6 +390,7 @@ impl SimpleConstraintChecker for FreeKittyConstraintChecker {
         &self,
         input_data: &[DynamicallyTypedData],
         _peeks: &[DynamicallyTypedData],
+        _evictions: &[DynamicallyTypedData],
         output_data: &[DynamicallyTypedData],
     ) -> Result<TransactionPriority, Self::Error> {
         // Input must be a Mom and a Dad

--- a/tuxedo-template-runtime/src/lib.rs
+++ b/tuxedo-template-runtime/src/lib.rs
@@ -306,14 +306,20 @@ impl ConstraintChecker for OuterConstraintChecker {
             Self::FreeKittyConstraintChecker(free_breed) => {
                 free_breed.check(inputs, peeks, evictions, outputs)?
             }
-            Self::AmoebaMitosis(amoeba_mitosis) => amoeba_mitosis.check(inputs, peeks, evictions, outputs)?,
-            Self::AmoebaDeath(amoeba_death) => amoeba_death.check(inputs, peeks, evictions, outputs)?,
+            Self::AmoebaMitosis(amoeba_mitosis) => {
+                amoeba_mitosis.check(inputs, peeks, evictions, outputs)?
+            }
+            Self::AmoebaDeath(amoeba_death) => {
+                amoeba_death.check(inputs, peeks, evictions, outputs)?
+            }
             Self::AmoebaCreation(amoeba_creation) => {
                 amoeba_creation.check(inputs, peeks, evictions, outputs)?
             }
             Self::PoeClaim(poe_claim) => poe_claim.check(inputs, peeks, evictions, outputs)?,
             Self::PoeRevoke(poe_revoke) => poe_revoke.check(inputs, peeks, evictions, outputs)?,
-            Self::PoeDispute(poe_dispute) => poe_dispute.check(inputs, peeks, evictions, outputs)?,
+            Self::PoeDispute(poe_dispute) => {
+                poe_dispute.check(inputs, peeks, evictions, outputs)?
+            }
             Self::RuntimeUpgrade(runtime_upgrade) => {
                 runtime_upgrade.check(inputs, peeks, evictions, outputs)?
             }

--- a/tuxedo-template-runtime/src/lib.rs
+++ b/tuxedo-template-runtime/src/lib.rs
@@ -297,24 +297,25 @@ impl ConstraintChecker for OuterConstraintChecker {
     fn check<V: Verifier>(
         &self,
         inputs: &[Output<V>],
+        evictions: &[Output<V>],
         peeks: &[Output<V>],
         outputs: &[Output<V>],
     ) -> Result<TransactionPriority, OuterConstraintCheckerError> {
         Ok(match self {
-            Self::Money(money) => money.check(inputs, peeks, outputs)?,
+            Self::Money(money) => money.check(inputs, peeks, evictions, outputs)?,
             Self::FreeKittyConstraintChecker(free_breed) => {
-                free_breed.check(inputs, peeks, outputs)?
+                free_breed.check(inputs, peeks, evictions, outputs)?
             }
-            Self::AmoebaMitosis(amoeba_mitosis) => amoeba_mitosis.check(inputs, peeks, outputs)?,
-            Self::AmoebaDeath(amoeba_death) => amoeba_death.check(inputs, peeks, outputs)?,
+            Self::AmoebaMitosis(amoeba_mitosis) => amoeba_mitosis.check(inputs, peeks, evictions, outputs)?,
+            Self::AmoebaDeath(amoeba_death) => amoeba_death.check(inputs, peeks, evictions, outputs)?,
             Self::AmoebaCreation(amoeba_creation) => {
-                amoeba_creation.check(inputs, peeks, outputs)?
+                amoeba_creation.check(inputs, peeks, evictions, outputs)?
             }
-            Self::PoeClaim(poe_claim) => poe_claim.check(inputs, peeks, outputs)?,
-            Self::PoeRevoke(poe_revoke) => poe_revoke.check(inputs, peeks, outputs)?,
-            Self::PoeDispute(poe_dispute) => poe_dispute.check(inputs, peeks, outputs)?,
+            Self::PoeClaim(poe_claim) => poe_claim.check(inputs, peeks, evictions, outputs)?,
+            Self::PoeRevoke(poe_revoke) => poe_revoke.check(inputs, peeks, evictions, outputs)?,
+            Self::PoeDispute(poe_dispute) => poe_dispute.check(inputs, peeks, evictions, outputs)?,
             Self::RuntimeUpgrade(runtime_upgrade) => {
-                runtime_upgrade.check(inputs, peeks, outputs)?
+                runtime_upgrade.check(inputs, peeks, evictions, outputs)?
             }
         })
     }

--- a/tuxedo-template-runtime/src/money.rs
+++ b/tuxedo-template-runtime/src/money.rs
@@ -85,6 +85,7 @@ impl SimpleConstraintChecker for MoneyConstraintChecker {
         &self,
         input_data: &[DynamicallyTypedData],
         _peeks: &[DynamicallyTypedData],
+        _evictions: &[DynamicallyTypedData],
         output_data: &[DynamicallyTypedData],
     ) -> Result<TransactionPriority, Self::Error> {
         match &self {
@@ -176,7 +177,7 @@ mod test {
         let expected_priority = 1u64;
 
         assert_eq!(
-            MoneyConstraintChecker::Spend.check(&input_data, &[], &output_data),
+            MoneyConstraintChecker::Spend.check(&input_data, &[], &[], &output_data),
             Ok(expected_priority),
         );
     }
@@ -187,7 +188,7 @@ mod test {
         let output_data = vec![Coin(10).into(), Coin(1).into(), Coin(0).into()]; // total 1164;
 
         assert_eq!(
-            MoneyConstraintChecker::Spend.check(&input_data, &[], &output_data),
+            MoneyConstraintChecker::Spend.check(&input_data, &[], &[], &output_data),
             Err(ConstraintCheckerError::ZeroValueCoin),
         );
     }
@@ -199,7 +200,7 @@ mod test {
         let expected_priority = 12u64;
 
         assert_eq!(
-            MoneyConstraintChecker::Spend.check(&input_data, &[], &output_data),
+            MoneyConstraintChecker::Spend.check(&input_data, &[], &[], &output_data),
             Ok(expected_priority),
         );
     }
@@ -210,7 +211,7 @@ mod test {
         let output_data = vec![Coin(10).into(), Coin(1).into()];
 
         assert_eq!(
-            MoneyConstraintChecker::Spend.check(&input_data, &[], &output_data),
+            MoneyConstraintChecker::Spend.check(&input_data, &[], &[], &output_data),
             Err(ConstraintCheckerError::SpendingNothing),
         );
     }
@@ -221,7 +222,7 @@ mod test {
         let output_data = vec![Coin(10).into(), Coin(1).into()];
 
         assert_eq!(
-            MoneyConstraintChecker::Spend.check(&input_data, &[], &output_data),
+            MoneyConstraintChecker::Spend.check(&input_data, &[], &[], &output_data),
             Err(ConstraintCheckerError::BadlyTyped),
         );
     }
@@ -232,7 +233,7 @@ mod test {
         let output_data = vec![Bogus.into()];
 
         assert_eq!(
-            MoneyConstraintChecker::Spend.check(&input_data, &[], &output_data),
+            MoneyConstraintChecker::Spend.check(&input_data, &[], &[], &output_data),
             Err(ConstraintCheckerError::BadlyTyped),
         );
     }
@@ -243,7 +244,7 @@ mod test {
         let output_data = vec![Coin(5).into(), Coin(7).into()]; // total 12
 
         assert_eq!(
-            MoneyConstraintChecker::Spend.check(&input_data, &[], &output_data),
+            MoneyConstraintChecker::Spend.check(&input_data, &[], &[], &output_data),
             Err(ConstraintCheckerError::OutputsExceedInputs),
         );
     }
@@ -254,7 +255,7 @@ mod test {
         let output_data = vec![Coin(10).into(), Coin(1).into()];
 
         assert_eq!(
-            MoneyConstraintChecker::Mint.check(&input_data, &[], &output_data),
+            MoneyConstraintChecker::Mint.check(&input_data, &[], &[], &output_data),
             Ok(0),
         );
     }
@@ -265,7 +266,7 @@ mod test {
         let output_data = vec![Coin(0).into()];
 
         assert_eq!(
-            MoneyConstraintChecker::Mint.check(&input_data, &[], &output_data),
+            MoneyConstraintChecker::Mint.check(&input_data, &[], &[], &output_data),
             Err(ConstraintCheckerError::ZeroValueCoin),
         );
     }
@@ -276,7 +277,7 @@ mod test {
         let output_data = vec![Coin(10).into(), Coin(1).into()];
 
         assert_eq!(
-            MoneyConstraintChecker::Mint.check(&input_data, &[], &output_data),
+            MoneyConstraintChecker::Mint.check(&input_data, &[], &[], &output_data),
             Err(ConstraintCheckerError::MintingWithInputs),
         );
     }
@@ -287,7 +288,7 @@ mod test {
         let output_data = vec![];
 
         assert_eq!(
-            MoneyConstraintChecker::Mint.check(&input_data, &[], &output_data),
+            MoneyConstraintChecker::Mint.check(&input_data, &[], &[], &output_data),
             Err(ConstraintCheckerError::MintingNothing),
         );
     }
@@ -298,7 +299,7 @@ mod test {
         let output_data = vec![Coin(10).into(), Bogus.into()];
 
         assert_eq!(
-            MoneyConstraintChecker::Mint.check(&input_data, &[], &output_data),
+            MoneyConstraintChecker::Mint.check(&input_data, &[], &[], &output_data),
             Err(ConstraintCheckerError::BadlyTyped),
         );
     }

--- a/tuxedo-template-runtime/src/poe.rs
+++ b/tuxedo-template-runtime/src/poe.rs
@@ -209,7 +209,7 @@ impl SimpleConstraintChecker for PoeDispute {
         );
         let winner: ClaimData = peek_data[1]
             .extract()
-            .map_err(|_| ConstraintCheckerError::BadlyTypedInput);
+            .map_err(|_| ConstraintCheckerError::BadlyTypedInput)?;
 
         // Check the winner against the losers.
         // 1. All losers claim the same hash as the winner.
@@ -217,7 +217,7 @@ impl SimpleConstraintChecker for PoeDispute {
         for untyped_loser in eviction_data {
             let loser: ClaimData = untyped_loser
                 .extract()
-                .map_err(|_| ConstraintCheckerError::BadlyTypedInput);
+                .map_err(|_| ConstraintCheckerError::BadlyTypedInput)?;
             ensure!(
                 winner.claim == loser.claim,
                 ConstraintCheckerError::DisputedClaimsNotForSameHash

--- a/tuxedo-template-runtime/src/poe.rs
+++ b/tuxedo-template-runtime/src/poe.rs
@@ -102,6 +102,7 @@ impl SimpleConstraintChecker for PoeClaim {
         &self,
         input_data: &[DynamicallyTypedData],
         _peeks: &[DynamicallyTypedData],
+        _evictions: &[DynamicallyTypedData],
         output_data: &[DynamicallyTypedData],
     ) -> Result<TransactionPriority, Self::Error> {
         // Make sure there are no inputs
@@ -149,6 +150,7 @@ impl SimpleConstraintChecker for PoeRevoke {
         &self,
         input_data: &[DynamicallyTypedData],
         _peeks: &[DynamicallyTypedData],
+        _evictions: &[DynamicallyTypedData],
         output_data: &[DynamicallyTypedData],
     ) -> Result<TransactionPriority, Self::Error> {
         // Make sure there are no outputs

--- a/tuxedo-template-runtime/src/poe.rs
+++ b/tuxedo-template-runtime/src/poe.rs
@@ -187,23 +187,45 @@ impl SimpleConstraintChecker for PoeDispute {
         output_data: &[DynamicallyTypedData],
     ) -> Result<TransactionPriority, Self::Error> {
         // Make sure there are no inputs to be normally consumed
-        ensure!(input_data.is_empty(), ConstraintCheckerError::DisputeWithInput);
+        ensure!(
+            input_data.is_empty(),
+            ConstraintCheckerError::DisputeWithInput
+        );
 
         // Make sure there are no outputs to be created
-        ensure!(output_data.is_empty(), ConstraintCheckerError::DisputeWithOutput);
+        ensure!(
+            output_data.is_empty(),
+            ConstraintCheckerError::DisputeWithOutput
+        );
 
         // Make sure there is exactly one peek: the claim that will be retained.
-        ensure!(!peek_data.is_empty(), ConstraintCheckerError::DisputeWithNoPeek);
-        ensure!(peek_data.len() == 1, ConstraintCheckerError::DisputeWithMultiplePeeks);
-        let winner: ClaimData = peek_data[1].extract().map_err(|_| ConstraintCheckerError::BadlyTypedInput);
+        ensure!(
+            !peek_data.is_empty(),
+            ConstraintCheckerError::DisputeWithNoPeek
+        );
+        ensure!(
+            peek_data.len() == 1,
+            ConstraintCheckerError::DisputeWithMultiplePeeks
+        );
+        let winner: ClaimData = peek_data[1]
+            .extract()
+            .map_err(|_| ConstraintCheckerError::BadlyTypedInput);
 
         // Check the winner against the losers.
         // 1. All losers claim the same hash as the winner.
         // 2. All losers have effective block heights strictly greater than the winner.
         for untyped_loser in eviction_data {
-            let loser: ClaimData = untyped_loser.extract().map_err(|_| ConstraintCheckerError::BadlyTypedInput);
-            ensure!(winner.claim == loser.claim, ConstraintCheckerError::DisputedClaimsNotForSameHash);
-            ensure!(winner.effective_height > loser.effective_height, ConstraintCheckerError::DisputeSettledIncorrectly);
+            let loser: ClaimData = untyped_loser
+                .extract()
+                .map_err(|_| ConstraintCheckerError::BadlyTypedInput);
+            ensure!(
+                winner.claim == loser.claim,
+                ConstraintCheckerError::DisputedClaimsNotForSameHash
+            );
+            ensure!(
+                winner.effective_height > loser.effective_height,
+                ConstraintCheckerError::DisputeSettledIncorrectly
+            );
         }
 
         Ok(0)

--- a/tuxedo-template-runtime/src/runtime_upgrade.rs
+++ b/tuxedo-template-runtime/src/runtime_upgrade.rs
@@ -81,6 +81,7 @@ impl SimpleConstraintChecker for RuntimeUpgrade {
         &self,
         input_data: &[DynamicallyTypedData],
         _peeks: &[DynamicallyTypedData],
+        _evictions: &[DynamicallyTypedData],
         output_data: &[DynamicallyTypedData],
     ) -> Result<TransactionPriority, Self::Error> {
         // Make sure there is a single input that matches the hash of the previous runtime logic

--- a/wallet/src/amoeba.rs
+++ b/wallet/src/amoeba.rs
@@ -25,6 +25,7 @@ pub async fn amoeba_demo(client: &HttpClient) -> anyhow::Result<()> {
     let spawn_tx = Transaction {
         inputs: Vec::new(),
         peeks: Vec::new(),
+        evictions: Vec::new(),
         outputs: vec![Output {
             payload: eve.into(),
             verifier: UpForGrabs.into(),
@@ -69,6 +70,7 @@ pub async fn amoeba_demo(client: &HttpClient) -> anyhow::Result<()> {
             redeemer: Vec::new(),
         }],
         peeks: Vec::new(),
+        evictions: Vec::new(),
         outputs: vec![
             Output {
                 payload: cain.into(),

--- a/wallet/src/money.rs
+++ b/wallet/src/money.rs
@@ -26,6 +26,7 @@ pub async fn spend_coins(client: &HttpClient, args: SpendArgs) -> anyhow::Result
     let mut transaction = Transaction {
         inputs: Vec::new(),
         peeks: Vec::new(),
+        evictions: Vec::new(),
         outputs: Vec::new(),
         checker: OuterConstraintChecker::Money(MoneyConstraintChecker::Spend),
     };


### PR DESCRIPTION
This PR builds off of #49. And it currently uses that branch as its base branch to make the eviction-related changes more obvious.

This PR is open for discussion and review. I'm not sure whether this is the best way to proceed, but it is an idea I've had around for a while so I decided to code it up.

In general, evictions are a way for a tracnsaction to read and consume some state (similar to an input) without having to satisfy the input's verifier. This could be used to clean up old or irrelevant state. For one example, it could be used to clean up `ThresholdMultiSignature`s that were constructed with duplicate signatories and are therefore never able to be consumed (It is an alternative to #51 in that sense).

For another example, see the `PoeDispute` `ConstraintChecker` included in this PR. This allows owners of proof-of-existence claims to evict claims for the same data that came later. 