### PR TITLE
Wallet Readme

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2368,6 +2368,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ebdb29d2ea9ed0083cd8cece49bbd968021bd99b0849edb4a9a7ee0fdf6a4e0"
 
 [[package]]
+name = "hex-literal"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
+
+[[package]]
 name = "hkdf"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8008,7 +8014,7 @@ dependencies = [
 name = "tuxedo-template-runtime"
 version = "1.0.0-dev"
 dependencies = [
- "hex-literal",
+ "hex-literal 0.3.4",
  "log",
  "parity-scale-codec",
  "parity-util-mem",
@@ -8043,10 +8049,12 @@ dependencies = [
  "anyhow",
  "clap",
  "directories 5.0.0",
+ "env_logger",
  "futures",
  "hex",
- "hex-literal",
+ "hex-literal 0.4.1",
  "jsonrpsee",
+ "log",
  "parity-scale-codec",
  "sc-keystore",
  "serde_json",

--- a/README.md
+++ b/README.md
@@ -77,8 +77,8 @@ Special thanks to the [Web 3 Foundation](https://web3.foundation/) for their sup
 As part of this grant we will deliver three milestones. More details are available in the [Tuxedo grant application](https://github.com/w3f/Grants-Program/blob/master/applications/tuxedo.md).
 
 - ✅ Core Tuxedo Functionality (complete)
-- 🏗️ User wallet (in development)
-- 🔜 Full Documentation and Tutorial (not yet started)
+- ✅ Template wallet (complete)
+- 🏗️ Full Documentation and Tutorial (in progress)
 
 After the grant work is complete we intend to continue developing Tuxedo. The future is less clear, but our current ideas include:
 

--- a/README.md
+++ b/README.md
@@ -119,30 +119,16 @@ Then, in a separate terminal, experiment with the PoC wallet.
 # Check out the minimal PoC CLI
 ./target/release/tuxedo-template-wallet --help
 
-# Confirm that a 100 token genesis utxo is present in storage
-./target/release/tuxedo-template-wallet verify-coin 000000000000000000000000000000000000000000000000000000000000000000000000
+# Check your balance
+./target/release/tuxedo-template-wallet show-balance
 
-  000000000000000000000000000000000000000000000000000000000000000000000000: owner 0xd2bf4b844dfefd6772a8843e669f943408966a977e3ae2af1dd78e0f55f4df67, amount 100
-  Details of coin 000000000000000000000000000000000000000000000000000000000000000000000000:
-  Found in storage.  Value: 100, owned by 0xd2bf…df67
-  Found in local db. Value: 100, owned by 0xd2bf…df67
+Balance Summary
+0xd2bf…df67: 100
+--------------------
+total      : 100
 
-# Generate a new key or insert a pre generated other key
-./target/release/tuxedo-template-wallet generate-key
-
-  Generated public key is f41a866782d45a4d2d8a623a097c62aee6955a9e580985e3910ba49eded9e06b (5HamRMAa...)
-  Generated Phrase is decide city tattoo arrest jeans split main sad slam blame crack farm
-
-# or to continue on with demo just insert the following generated key
-
-# Inserting new generated key
-./target/release/tuxedo-template-wallet insert-key "decide city tattoo arrest jeans split main sad slam blame crack farm"
-
-  The generated public key is f41a866782d45a4d2d8a623a097c62aee6955a9e580985e3910ba49eded9e06b (5HamRMAa...)
-
-# Split the 100 tokens into two of values 20 and 25, burning the remaining 5
+# Split the 100 genesis tokens into two of values 20 and 25, burning the remaining 55
 ./target/release/tuxedo-template-wallet spend-coins \
-  --input 000000000000000000000000000000000000000000000000000000000000000000000000 \
   --output-amount 20 \
   --output-amount 25
 
@@ -150,24 +136,16 @@ Then, in a separate terminal, experiment with the PoC wallet.
   Created "337395dec41937478bb55c4e8c75911cbec061511ddbc38163b94e4386f1228c01000000" worth 25. owned by 0xd2bf…df67
 
 
-# Further split the 25 token utxo into 10 and 5 given to a new address, burning the remaining 10
-./target/release/tuxedo-template-wallet spend-coins \
-  --input $UTXO_FROM_ABOVE! 337395dec41937478bb55c4e8c75911cbec061511ddbc38163b94e4386f1228c01000000 \
-  --recipient 0x42ef192744a0c9af409039e77b1b001e45f4f7553a7acd3b9dc06621c6a22a43 \
-  --output-amount 10 \
-  --output-amount 5
+# Check your balance again to confirm the burn worked
+./target/release/tuxedo-template-wallet show-balance
 
-  Created "5bf5941daf1e1484b04ec7ee1d4c63012a0b244f8d0dc523368f6251bd823a8600000000" worth 10. owned by 0x42ef…2a43
-  Created "5bf5941daf1e1484b04ec7ee1d4c63012a0b244f8d0dc523368f6251bd823a8601000000" worth 5. owned by 0x42ef…2a43
-
-# Join the 20 token utxo and 10 token utxo back into a single 30 token utxo, burning nothing
-./target/release/tuxedo-template-wallet spend-coins \
-  --input 5bf5941daf1e1484b04ec7ee1d4c63012a0b244f8d0dc523368f6251bd823a8600000000 \
-  --input 337395dec41937478bb55c4e8c75911cbec061511ddbc38163b94e4386f1228c00000000 \
-  --output-amount 30
-
-  Created "de8710e5b2bd5306b3cb238d8995b6e630a47189af6240b02d0e7140a3a8620400000000" worth 30. owned by 0xd2bf…df67
+Balance Summary
+0xd2bf…df67: 45
+--------------------
+total      : 45
 ```
+
+There is a more detailed walkthrough of the wallet in the [Wallet README](wallet/README.md).
 
 ## Docker
 

--- a/wallet/Cargo.toml
+++ b/wallet/Cargo.toml
@@ -16,11 +16,13 @@ jsonrpsee = { version = "0.16.2", features = ["http-client"] }
 tokio = { version = "1.25.0", features = ["full"] }
 anyhow = "1.0.69"
 hex = "0.4.3"
-hex-literal = "0.3.4"
+hex-literal = "0.4.1"
 clap = { version = "4.1.8", features = [ "derive"] }
 directories = "5.0.0"
 sled = "0.34.7"
 futures = "0.3"
+env_logger = "0.10.0"
+log = "0.4.17"
 
 sp-runtime = { git = 'https://github.com/paritytech/substrate', tag = "monthly-2023-03" }
 sp-core = { git = 'https://github.com/paritytech/substrate', tag = "monthly-2023-03" }

--- a/wallet/README.md
+++ b/wallet/README.md
@@ -1,0 +1,234 @@
+# Tuxedo Template Wallet
+
+A cli wallet for the Tuxedo Node Template
+
+## Overview
+
+This wallet works with the Tuxedo Node Template and Tuxedo Template Runtime which is also contained in this repository.
+
+Like many UTXO wallets, this one synchronizes a local-to-the-wallet database of UTXOs that exist on the current best chain.
+The wallet does not sync the entire blockchain state.
+Rather, it syncs a subset of the state that it considers "relevant".
+Currently, the wallet syncs any UTXOs that contain tokens owned by a key in the wallet's keystore.
+However, the wallet is designed so that this notion of "relevance" is generalizeable.
+This design allows developers building chains with Tuxedo to extend the wallet for their own needs.
+However, because this is a text- based wallet, it is likely not well-suited for end users of popular dapps.
+
+## CLI Documentation
+
+The node application has a thorough help page that you can access on the CLI. It also has help pages for all subcommands. Please explore and read these docs thoroughly.
+
+```sh
+# Show the wallet's main help page
+$ tuxedo-template-wallet --help
+
+A simple example / template wallet built for the tuxedo template runtime
+
+Usage: tuxedo-template-wallet [OPTIONS] <COMMAND>
+
+Commands:
+
+...
+
+# Show the help for a subcommand
+$ tuxedo-template-wallet verify-coin --help
+Verify that a particular coin exists.
+
+Show its value and owner from both chain storage and the local database.
+
+Usage: tuxedo-template-wallet verify-coin <OUTPUT_REF>
+
+Arguments:
+  <OUTPUT_REF>
+          A hex-encoded output reference
+
+Options:
+  -h, --help
+          Print help (see a summary with '-h')
+```
+
+## Guided Tour
+
+This guided tour shows off some of the most common and important wallet features. It can serve as a quickstart, but is not a substitute for reading the help pages mentioned above. (Seriously, please rtfm).
+
+To follow this walkthrough, you should already have a fresh tuxedo template dev node running as described in the [main readme](../README.md). For example, `node-template --dev`.
+
+### Syncing up an Initial Wallet
+
+The wallet is not a long-running process.
+The wallet starts up, syncs with the latest chain state, performs the action invoked, and exits.
+
+Let's begin by just starting a new wallet and letting it sync.
+
+```sh
+$ tuxedo-template-wallet
+
+[2023-04-11T17:44:40Z INFO  tuxedo_template_wallet::sync] Initializing fresh sync from genesis 0x12aba3510dc0918aec178a32927f145d22d62afe63392713cb65b85570206327
+[2023-04-11T17:44:40Z INFO  tuxedo_template_wallet] Number of blocks in the db: 0
+[2023-04-11T17:44:40Z INFO  tuxedo_template_wallet] Wallet database synchronized with node to height 20
+[2023-04-11T17:44:40Z INFO  tuxedo_template_wallet] No Wallet Command invoked. Exiting.
+```
+
+The logs indicate that a fresh database was created and had no blocks in it. Then, by communicating with the node, the wallet was able to sync 20 blocks. Finally it tells us that we didn't ask the wallet to tell us any specific information or send any transactions, so it just exits.
+
+Let's run the same command again and see that the wallet persists state.
+
+```sh
+$ tuxedo-template-wallet
+
+[2023-04-11T17:46:17Z INFO  tuxedo_template_wallet] Number of blocks in the db: 20
+[2023-04-11T17:46:17Z INFO  tuxedo_template_wallet] Wallet database synchronized with node to height 52
+[2023-04-11T17:46:17Z INFO  tuxedo_template_wallet] No Wallet Command invoked. Exiting.
+```
+
+This time, it is not a fresh database. In fact it starts from block 20, where it left off previously, and syncs up to block 52. Again, we didn't tell the wallet any specific action to take, so it just exits.
+
+We can also tell the wallet to skip the initial sync if we want to for any reason.
+```sh
+$ tuxedo-template-wallet --no-sync
+
+[2023-04-11T17:47:48Z INFO  tuxedo_template_wallet] Number of blocks in the db: 52
+[2023-04-11T17:47:48Z WARN  tuxedo_template_wallet] Skipping sync with node. Using previously synced information.
+[2023-04-11T17:47:48Z INFO  tuxedo_template_wallet] No Wallet Command invoked. Exiting.
+```
+
+Now that we understand that the wallet syncs up with the node each time it starts, let's explore our first wallet command. Like most wallets, it will tell you how many tokens you own.
+
+```sh
+$ tuxedo-template-wallet show-balance
+
+[2023-04-11T18:07:52Z INFO  tuxedo_template_wallet] Number of blocks in the db: 52
+[2023-04-11T18:07:52Z INFO  tuxedo_template_wallet] Wallet database synchronized with node to height 55
+Balance Summary
+0xd2bf…df67: 100
+--------------------
+total      : 100
+```
+The wallet begins by syncing the blockchain state, as usual.
+Then it shows us that it knows about this `0xd2bf...` account.
+This is the test account, or the "SHAWN" account.
+The wallet already contains these keys so you can start learning quickly.
+And it seems this account has some money.
+Let's look further.
+
+### Exploring the Genesis Coin
+
+The chain begins with a single coin in storage.
+We can confirm that the node and the wallet are familiar with the genesis coin using the `verify-coin` subcommand.
+
+```sh
+$ tuxedo-template-wallet verify-coin 000000000000000000000000000000000000000000000000000000000000000000000000
+
+[2023-04-11T17:50:04Z INFO  tuxedo_template_wallet] Number of blocks in the db: 52
+[2023-04-11T17:50:04Z INFO  tuxedo_template_wallet] Wallet database synchronized with node to height 128
+Details of coin 000000000000000000000000000000000000000000000000000000000000000000000000:
+Found in storage.  Value: 100, owned by 0xd2bf…df67
+Found in local db. Value: 100, owned by 0xd2bf…df67
+```
+
+After syncing, it tells us the status of the coin that we are asking about.
+That number with all the `0`s is called an `OutputRef` and it is a unique way to refer to a utxo.
+The wallet tells us that the coin is found in the chain's storage and in the wallet's own local db.
+Both sources agree that the coin exists, is worth 100, and is owned by Shawn.
+
+Let's "split" this coin by creating a transaction that spends it and creates two new coins worth 40 and 50, burning the remaining 10.
+
+```sh
+$ tuxedo-template-wallet spend-coins \
+  --output-amount 40 \
+  --output-amount 50
+
+[2023-04-11T17:58:00Z INFO  tuxedo_template_wallet] Number of blocks in the db: 128
+[2023-04-11T17:58:00Z INFO  tuxedo_template_wallet] Wallet database synchronized with node to height 287
+[2023-04-11T17:58:00Z INFO  tuxedo_template_wallet] Node's response to spend transaction: Ok("0x1261bc4cf1d8ba65653948292f30c8c260d2a5d15047d4bedb9e9dd37e6a24d2")
+
+Created "7ff2d54aab484363676ba2380800b95dc646a594c55c35524505fe45de70d33d00000000" worth 40. owned by 0xd2bf…df67
+Created "7ff2d54aab484363676ba2380800b95dc646a594c55c35524505fe45de70d33d01000000" worth 50. owned by 0xd2bf…df67
+```
+
+Our command told the wallet to create a transaction that spends some coins (in this case the genesis coin) and creates two new coins with the given amounts, burning the remaining 10.
+It also tells us the `OutputRef`s of the new coins created.
+
+A balance check reveals that our balance has decreased by the 10 burnt tokes as expected.
+
+```sh
+TODO
+```
+
+In this case we didn't specify a recipient of the new outputs, so the same default address was used. Next let's explore using some other keys.
+
+### Using Your Own Keys
+
+Of course we can use other keys than the example Shawn key.
+The wallet supports generating our own keys, or inserting pre-existing keys.
+To follow this guide as closely as possible, you should insert the same key we generated.
+
+```sh
+# Generate a new key
+$ tuxedo-template-wallet generate-key
+
+  Generated public key is f41a866782d45a4d2d8a623a097c62aee6955a9e580985e3910ba49eded9e06b (5HamRMAa...)
+  Generated Phrase is decide city tattoo arrest jeans split main sad slam blame crack farm
+
+# Or, to continue on with demo, insert the same generated key
+$ tuxedo-template-wallet insert-key "decide city tattoo arrest jeans split main sad slam blame crack farm"
+
+  The generated public key is f41a866782d45a4d2d8a623a097c62aee6955a9e580985e3910ba49eded9e06b (5HamRMAa...)
+```
+
+With our new keys in the keystore, let's send some coins from Shawn to our own key.
+
+```sh
+TODO spend-coins \
+ --recipient f41a866782d45a4d2d8a623a097c62aee6955a9e580985e3910ba49eded9e06b \
+ --output-amount 20 \
+ --output-amount 10
+```
+
+This command will consume one of the existing coins, and create two new ones owned by our key.
+Our new coins will be worth 20 and 10 tokens.
+Let's check the balance summary to confirm.
+
+```sh
+TODO show-balance
+```
+
+### Manually Selecting Inputs
+
+So far, we have let the wallet select which inputs to spend on our behalf.
+This is typically fine, but some users like to select specific inputs for their transactions.
+The wallet supports this.
+But before we can spend specific inputs, let's learn how to print the complete list of unspent outputs.
+
+```sh
+TODO show-all-outputs
+```
+
+Now that we know precisely which outputs exist in our chain, we can choose to spend a specific one.
+Let's consume out 20 token input and send 15 of its coins to Shawn, burning the remaining 5.
+Because we are sending to Shawn, and Shawn is the default recipient, we could leave off the `--recipient` flag, but I'll choose to include it anyway.
+
+```sh
+spend-coins \
+  --input TODO \
+  --recipient TODO \
+  --output-amount 15
+
+
+```
+
+You should confirm for yourself that both the balance summary and the complete list of UTXOs look as you expect.
+
+### Multi Owner
+
+The final wallet feature that we will demonstrate is its ability to construct transactions with inputs coming from multiple different owners.
+
+Here we will create a transaction with a single output worth 70 units owned by some address that we'll call Jose, and we'll let the wallet select the inputs itself.
+This will require inputs from both Shawn and us, and the wallet is able to handle this.
+
+```sh
+TODO
+```
+
+Now we check the balance summary and find it is empty.
+That is because Jose's keys are not in the keystore, so the wallet does not track his tokens.

--- a/wallet/README.md
+++ b/wallet/README.md
@@ -119,8 +119,8 @@ We can confirm that the node and the wallet are familiar with the genesis coin u
 ```sh
 $ tuxedo-template-wallet verify-coin 000000000000000000000000000000000000000000000000000000000000000000000000
 
-[2023-04-11T17:50:04Z INFO  tuxedo_template_wallet] Number of blocks in the db: 52
-[2023-04-11T17:50:04Z INFO  tuxedo_template_wallet] Wallet database synchronized with node to height 128
+[2023-04-11T17:50:04Z INFO  tuxedo_template_wallet] Number of blocks in the db: 55
+[2023-04-11T17:50:04Z INFO  tuxedo_template_wallet] Wallet database synchronized with node to height 80
 Details of coin 000000000000000000000000000000000000000000000000000000000000000000000000:
 Found in storage.  Value: 100, owned by 0xd2bf…df67
 Found in local db. Value: 100, owned by 0xd2bf…df67
@@ -138,12 +138,12 @@ $ tuxedo-template-wallet spend-coins \
   --output-amount 40 \
   --output-amount 50
 
-[2023-04-11T17:58:00Z INFO  tuxedo_template_wallet] Number of blocks in the db: 128
-[2023-04-11T17:58:00Z INFO  tuxedo_template_wallet] Wallet database synchronized with node to height 287
-[2023-04-11T17:58:00Z INFO  tuxedo_template_wallet] Node's response to spend transaction: Ok("0x1261bc4cf1d8ba65653948292f30c8c260d2a5d15047d4bedb9e9dd37e6a24d2")
+[2023-04-11T17:58:00Z INFO  tuxedo_template_wallet] Number of blocks in the db: 80
+[2023-04-11T17:58:00Z INFO  tuxedo_template_wallet] Wallet database synchronized with node to height 87
+[2023-04-11T17:58:00Z INFO  tuxedo_template_wallet] Node's response to spend transaction: Ok("0xad0de5922a27fab1a3ce116868ada789677c80a0e70018bd32464b2e737d3546")
 
-Created "7ff2d54aab484363676ba2380800b95dc646a594c55c35524505fe45de70d33d00000000" worth 40. owned by 0xd2bf…df67
-Created "7ff2d54aab484363676ba2380800b95dc646a594c55c35524505fe45de70d33d01000000" worth 50. owned by 0xd2bf…df67
+Created "9b3b0d17ad5f7784e840c40089d4d0aa0de990c5c620d49a0729c3a45afa35bf00000000" worth 40. owned by 0xd2bf…df67
+Created "9b3b0d17ad5f7784e840c40089d4d0aa0de990c5c620d49a0729c3a45afa35bf01000000" worth 50. owned by 0xd2bf…df67
 ```
 
 Our command told the wallet to create a transaction that spends some coins (in this case the genesis coin) and creates two new coins with the given amounts, burning the remaining 10.
@@ -152,7 +152,16 @@ It also tells us the `OutputRef`s of the new coins created.
 A balance check reveals that our balance has decreased by the 10 burnt tokes as expected.
 
 ```sh
-TODO
+$ tuxedo-template-wallet show-balance
+
+[2023-04-11T18:52:26Z INFO  tuxedo_template_wallet] Number of blocks in the db: 87
+[2023-04-11T18:52:26Z INFO  tuxedo_template_wallet] Wallet database synchronized with node to height 95
+
+Balance Summary
+0xd2bf…df67: 90
+--------------------
+total      : 90
+
 ```
 
 In this case we didn't specify a recipient of the new outputs, so the same default address was used. Next let's explore using some other keys.
@@ -179,10 +188,17 @@ $ tuxedo-template-wallet insert-key "decide city tattoo arrest jeans split main 
 With our new keys in the keystore, let's send some coins from Shawn to our own key.
 
 ```sh
-TODO spend-coins \
+$ tuxedo-template-wallet spend-coins \
  --recipient f41a866782d45a4d2d8a623a097c62aee6955a9e580985e3910ba49eded9e06b \
  --output-amount 20 \
  --output-amount 10
+
+[2023-04-11T18:53:46Z INFO  tuxedo_template_wallet] Number of blocks in the db: 95
+[2023-04-11T18:53:46Z INFO  tuxedo_template_wallet] Wallet database synchronized with node to height 99
+[2023-04-11T18:53:46Z INFO  tuxedo_template_wallet::money] Node's response to spend transaction: Ok("0x7b8466f6c418637958f8090304dbdd7f115c27abf787b8f034a41d522bdf2baf")
+
+Created "90695702dabcca93d2c5f84a45b07bf59626ddb49a9b5255e202777127a3323d00000000" worth 20. owned by 0xf41a…e06b
+Created "90695702dabcca93d2c5f84a45b07bf59626ddb49a9b5255e202777127a3323d01000000" worth 10. owned by 0xf41a…e06b
 ```
 
 This command will consume one of the existing coins, and create two new ones owned by our key.
@@ -190,7 +206,16 @@ Our new coins will be worth 20 and 10 tokens.
 Let's check the balance summary to confirm.
 
 ```sh
-TODO show-balance
+$ tuxedo-template-wallet show-balance
+
+[2023-04-11T18:54:42Z INFO  tuxedo_template_wallet] Number of blocks in the db: 99
+[2023-04-11T18:54:42Z INFO  tuxedo_template_wallet] Wallet database synchronized with node to height 101
+
+Balance Summary
+0xd2bf…df67: 50
+0xf41a…e06b: 30
+--------------------
+total      : 80
 ```
 
 ### Manually Selecting Inputs
@@ -201,20 +226,33 @@ The wallet supports this.
 But before we can spend specific inputs, let's learn how to print the complete list of unspent outputs.
 
 ```sh
-TODO show-all-outputs
+$ tuxedo-template-wallet show-all-outputs
+
+[2023-04-11T18:55:23Z INFO  tuxedo_template_wallet] Number of blocks in the db: 101
+[2023-04-11T18:55:23Z INFO  tuxedo_template_wallet] Wallet database synchronized with node to height 104
+
+###### Unspent outputs ###########
+90695702dabcca93d2c5f84a45b07bf59626ddb49a9b5255e202777127a3323d00000000: owner 0xf41a866782d45a4d2d8a623a097c62aee6955a9e580985e3910ba49eded9e06b, amount 20
+90695702dabcca93d2c5f84a45b07bf59626ddb49a9b5255e202777127a3323d01000000: owner 0xf41a866782d45a4d2d8a623a097c62aee6955a9e580985e3910ba49eded9e06b, amount 10
+9b3b0d17ad5f7784e840c40089d4d0aa0de990c5c620d49a0729c3a45afa35bf01000000: owner 0xd2bf4b844dfefd6772a8843e669f943408966a977e3ae2af1dd78e0f55f4df67, amount 50
 ```
 
 Now that we know precisely which outputs exist in our chain, we can choose to spend a specific one.
-Let's consume out 20 token input and send 15 of its coins to Shawn, burning the remaining 5.
+Let's consume our 20 token input and send 15 of its coins to Shawn, burning the remaining 5.
 Because we are sending to Shawn, and Shawn is the default recipient, we could leave off the `--recipient` flag, but I'll choose to include it anyway.
 
 ```sh
-spend-coins \
-  --input TODO \
-  --recipient TODO \
+# The input value has to be copied from your own `show-all-outputs` results
+$ tuxedo-template-wallet spend-coins \
+  --input 90695702dabcca93d2c5f84a45b07bf59626ddb49a9b5255e202777127a3323d00000000 \
+  --recipient 0xd2bf4b844dfefd6772a8843e669f943408966a977e3ae2af1dd78e0f55f4df67 \
   --output-amount 15
 
+[2023-04-11T18:57:20Z INFO  tuxedo_template_wallet] Number of blocks in the db: 94
+[2023-04-11T18:57:20Z INFO  tuxedo_template_wallet] Wallet database synchronized with node to height 133
+[2023-04-11T18:57:20Z INFO  tuxedo_template_wallet::money] Node's response to spend transaction: Ok("0x80018b868d1e29be5cb758e15618091da8185cd7256ae3338df4605732fcfe9f")
 
+Created "4788fd9d517af94c2cfac80cb23fa6a63c41784b6fab01efd5d33b907af2550500000000" worth 15. owned by 0xd2bf…df67
 ```
 
 You should confirm for yourself that both the balance summary and the complete list of UTXOs look as you expect.
@@ -227,7 +265,15 @@ Here we will create a transaction with a single output worth 70 units owned by s
 This will require inputs from both Shawn and us, and the wallet is able to handle this.
 
 ```sh
-TODO
+$ tuxedo-template-wallet spend-coins \
+  --recipient 0x066ae8f6f5c3f04e7fc163555d6ef62f6f8878435a931ba7eaf02424a16afe62 \
+  --output-amount 70
+
+[2023-04-11T18:59:18Z INFO  tuxedo_template_wallet] Number of blocks in the db: 146
+[2023-04-11T18:59:18Z INFO  tuxedo_template_wallet] Wallet database synchronized with node to height 173
+[2023-04-11T18:59:19Z INFO  tuxedo_template_wallet::money] Node's response to spend transaction: Ok("0x04efb1c55f4efacbe41d00d3c5fe554470328a37150df6053bd48088e73a023c")
+
+Created "d0f722019e05863769e64ac6d33ad3ebeb359ce0469e93a9856bfcc236c4bad700000000" worth 70. owned by 0x066a…fe62
 ```
 
 Now we check the balance summary and find it is empty.

--- a/wallet/src/cli.rs
+++ b/wallet/src/cli.rs
@@ -27,7 +27,7 @@ pub struct Cli {
 
     #[arg(long)]
     /// Skip the initial sync that the wallet typically performs with the node.
-    /// 
+    ///
     /// The wallet will use the latest data it had previously synced.
     pub no_sync: bool,
 
@@ -42,7 +42,7 @@ pub enum Command {
     AmoebaDemo,
 
     /// Verify that a particular coin exists.
-    /// 
+    ///
     /// Show its value and owner from both chain storage and the local database.
     VerifyCoin {
         /// A hex-encoded output reference

--- a/wallet/src/cli.rs
+++ b/wallet/src/cli.rs
@@ -26,7 +26,7 @@ pub struct Cli {
     pub data_path: Option<PathBuf>,
 
     #[command(subcommand)]
-    pub command: Command,
+    pub command: Option<Command>,
 }
 
 /// The tasks supported by the wallet
@@ -75,12 +75,12 @@ pub enum Command {
         pub_key: H256,
     },
 
-    /// Synchronizes the wallet up to the tip of the chain, and does nothing else.
-    SyncOnly,
-
     /// For each key tracked by the wallet, shows the sum of all UTXO values
     /// owned by that key. This sum is sometimes known as the "balance".
     ShowBalance,
+
+    /// Show the complete list of UTXOs known to the wallet.
+    ShowAllOutputs,
 }
 
 #[derive(Debug, Args)]

--- a/wallet/src/cli.rs
+++ b/wallet/src/cli.rs
@@ -41,7 +41,9 @@ pub enum Command {
     /// Demonstrate creating an amoeba and performing mitosis on it.
     AmoebaDemo,
 
-    /// Verify that a particular coin exists in storage. Show its value and owner.
+    /// Verify that a particular coin exists.
+    /// 
+    /// Show its value and owner from both chain storage and the local database.
     VerifyCoin {
         /// A hex-encoded output reference
         #[arg(value_parser = output_ref_from_string)]

--- a/wallet/src/cli.rs
+++ b/wallet/src/cli.rs
@@ -25,6 +25,12 @@ pub struct Cli {
     /// Default value is platform specific
     pub data_path: Option<PathBuf>,
 
+    #[arg(long)]
+    /// Skip the initial sync that the wallet typically performs with the node.
+    /// 
+    /// The wallet will use the latest data it had previously synced.
+    pub no_sync: bool,
+
     #[command(subcommand)]
     pub command: Option<Command>,
 }

--- a/wallet/src/main.rs
+++ b/wallet/src/main.rs
@@ -87,7 +87,6 @@ async fn main() -> anyhow::Result<()> {
     if cli.no_sync {
         log::warn!("Skipping sync with node. Using previously synced information.")
     } else {
-       
         sync::synchronize(&db, &client, &keystore_filter).await?;
 
         log::info!(
@@ -161,17 +160,17 @@ async fn main() -> anyhow::Result<()> {
             println!("total      : {total}");
 
             Ok(())
-        },
+        }
         Some(Command::ShowAllOutputs) => {
             println!("###### Unspent outputs ###########");
             sync::print_unspent_tree(&db)?;
 
             Ok(())
-        },
+        }
         None => {
             log::info!("No Wallet Command invoked. Exiting.");
             Ok(())
-        },
+        }
     }
 }
 

--- a/wallet/src/money.rs
+++ b/wallet/src/money.rs
@@ -58,12 +58,18 @@ pub async fn spend_coins(
         total_input_amount += amount;
     }
     //TODO filtering on a specific sender
-    while total_input_amount < total_output_amount {
-        let (output_ref, _owner_pubkey, amount) = sync::get_arbitrary_unspent(db)?;
-        all_input_refs.push(output_ref);
-        total_input_amount += amount;
-    }
 
+    // If the supplied inputs are not valuable enough to cover the output amount
+    // we select the rest arbitrarily from the local db. (In many cases, this will be all the inputs.)
+    if total_input_amount < total_output_amount {
+        match sync::get_arbitrary_unspent_set(db, total_output_amount - total_input_amount)? {
+            Some(more_inputs) => {
+                all_input_refs.extend(more_inputs);
+            },
+            None => Err(anyhow!("Not enough value in database to construct transaction"))?,
+        }
+    }
+    
     // Make sure each input decodes and is still present in the node's storage,
     // and then push to transaction.
     for output_ref in &all_input_refs {

--- a/wallet/src/money.rs
+++ b/wallet/src/money.rs
@@ -25,7 +25,7 @@ pub async fn spend_coins(
     keystore: &LocalKeystore,
     args: SpendArgs,
 ) -> anyhow::Result<()> {
-    println!("The args are:: {:?}", args);
+    log::debug!("The args are:: {:?}", args);
 
     // Construct a template Transaction to push coins into later
     let mut transaction = Transaction {
@@ -101,7 +101,7 @@ pub async fn spend_coins(
     let params = rpc_params![genesis_spend_hex];
     let genesis_spend_response: Result<String, _> =
         client.request("author_submitExtrinsic", params).await;
-    println!(
+    log::info!(
         "Node's response to spend transaction: {:?}",
         genesis_spend_response
     );

--- a/wallet/src/money.rs
+++ b/wallet/src/money.rs
@@ -65,11 +65,13 @@ pub async fn spend_coins(
         match sync::get_arbitrary_unspent_set(db, total_output_amount - total_input_amount)? {
             Some(more_inputs) => {
                 all_input_refs.extend(more_inputs);
-            },
-            None => Err(anyhow!("Not enough value in database to construct transaction"))?,
+            }
+            None => Err(anyhow!(
+                "Not enough value in database to construct transaction"
+            ))?,
         }
     }
-    
+
     // Make sure each input decodes and is still present in the node's storage,
     // and then push to transaction.
     for output_ref in &all_input_refs {

--- a/wallet/src/sync.rs
+++ b/wallet/src/sync.rs
@@ -225,10 +225,13 @@ pub(crate) fn get_unspent(db: &Db, output_ref: &OutputRef) -> anyhow::Result<Opt
 
 /// Picks an arbitrary set of unspent outputs from the database for spending.
 /// The set's token values must add up to at least the specified target value.
-/// 
+///
 /// The return value is None if the total value of the database is less than the target
 /// It is Some(Vec![...]) when it is possible
-pub(crate) fn get_arbitrary_unspent_set(db: &Db, target: u128) -> anyhow::Result<Option<Vec<OutputRef>>> {
+pub(crate) fn get_arbitrary_unspent_set(
+    db: &Db,
+    target: u128,
+) -> anyhow::Result<Option<Vec<OutputRef>>> {
     let wallet_unspent_tree = db.open_tree(UNSPENT)?;
 
     let mut total = 0u128;
@@ -247,7 +250,6 @@ pub(crate) fn get_arbitrary_unspent_set(db: &Db, target: u128) -> anyhow::Result
         total += amount;
         keepers.push(output_ref);
     }
-
 
     Ok(Some(keepers))
 }


### PR DESCRIPTION
Aka Joshy's final pass before milestone 2.

This PR:
* Adds a readme with a detailed walkthough in the wallet crate
* Fixes a bug where the wallet would select the same input multiple times for inclusion in a transaction
* Uses `env_logger` and `log` crates for better output logging
* Makes the CLI a little more intuitive