### PR TITLE
Multitoken

### DIFF
--- a/tuxedo-template-runtime/src/lib.rs
+++ b/tuxedo-template-runtime/src/lib.rs
@@ -30,6 +30,7 @@ use serde::{Deserialize, Serialize};
 pub mod amoeba;
 pub mod kitties;
 pub mod money;
+pub mod multitoken;
 mod poe;
 mod runtime_upgrade;
 use tuxedo_core::{
@@ -137,6 +138,13 @@ impl Default for GenesisConfig {
                         type_id: <money::Coin as UtxoData>::TYPE_ID,
                     },
                 },
+                Output {
+                    verifier: OuterVerifier::SigCheck(SigCheck {
+                        owner_pubkey: SHAWN_PUB_KEY_BYTES.into(),
+                    }),
+                    // TODO we should use .into() on the lines above too.
+                    payload: multitoken::Token { id: 0, value: 100 }.into()
+                },
             ],
         }
 
@@ -233,6 +241,8 @@ pub enum OuterConstraintChecker {
     PoeDispute(poe::PoeDispute),
     /// Upgrade the Wasm Runtime
     RuntimeUpgrade(runtime_upgrade::RuntimeUpgrade),
+    /// Monetary transaction in many distinct fungible currencies,
+    MultiToken(multitoken::SpendToken),
 }
 
 /// The main struct in this module.

--- a/tuxedo-template-runtime/src/lib.rs
+++ b/tuxedo-template-runtime/src/lib.rs
@@ -143,7 +143,7 @@ impl Default for GenesisConfig {
                         owner_pubkey: SHAWN_PUB_KEY_BYTES.into(),
                     }),
                     // TODO we should use .into() on the lines above too.
-                    payload: multitoken::Token { id: 0, value: 100 }.into()
+                    payload: multitoken::Token { id: 0, value: 100 }.into(),
                 },
             ],
         }

--- a/tuxedo-template-runtime/src/lib.rs
+++ b/tuxedo-template-runtime/src/lib.rs
@@ -125,7 +125,7 @@ impl Default for GenesisConfig {
                     }),
                     payload: DynamicallyTypedData {
                         data: 100u128.encode(),
-                        type_id: <money::Coin as UtxoData>::TYPE_ID,
+                        type_id: <money::Coin<0> as UtxoData>::TYPE_ID,
                     },
                 },
                 Output {
@@ -135,7 +135,7 @@ impl Default for GenesisConfig {
                     }),
                     payload: DynamicallyTypedData {
                         data: 100u128.encode(),
-                        type_id: <money::Coin as UtxoData>::TYPE_ID,
+                        type_id: <money::Coin<0> as UtxoData>::TYPE_ID,
                     },
                 },
                 Output {
@@ -223,7 +223,7 @@ pub enum OuterVerifier {
 #[tuxedo_constraint_checker]
 pub enum OuterConstraintChecker {
     /// Checks monetary transactions in a basic fungible cryptocurrency
-    Money(money::MoneyConstraintChecker),
+    Money(money::MoneyConstraintChecker<0>),
     /// Checks Free Kitty transactions
     FreeKittyConstraintChecker(kitties::FreeKittyConstraintChecker),
     /// Checks that an amoeba can split into two new amoebas
@@ -465,7 +465,7 @@ mod tests {
                 }),
                 payload: DynamicallyTypedData {
                     data: 100u128.encode(),
-                    type_id: <money::Coin as UtxoData>::TYPE_ID,
+                    type_id: <money::Coin<0> as UtxoData>::TYPE_ID,
                 },
             };
 
@@ -500,7 +500,7 @@ mod tests {
                 }),
                 payload: DynamicallyTypedData {
                     data: 100u128.encode(),
-                    type_id: <money::Coin as UtxoData>::TYPE_ID,
+                    type_id: <money::Coin<0> as UtxoData>::TYPE_ID,
                 },
             };
 

--- a/tuxedo-template-runtime/src/money.rs
+++ b/tuxedo-template-runtime/src/money.rs
@@ -183,7 +183,11 @@ mod test {
     #[test]
     fn spend_with_zero_value_output_fails() {
         let input_data = vec![Coin::<0>(5).into(), Coin::<0>(7).into()]; // total 12
-        let output_data = vec![Coin::<0>(10).into(), Coin::<0>(1).into(), Coin::<0>(0).into()]; // total 1164;
+        let output_data = vec![
+            Coin::<0>(10).into(),
+            Coin::<0>(1).into(),
+            Coin::<0>(0).into(),
+        ]; // total 1164;
 
         assert_eq!(
             MoneyConstraintChecker::<0>::Spend.check(&input_data, &output_data),

--- a/tuxedo-template-runtime/src/multitoken.rs
+++ b/tuxedo-template-runtime/src/multitoken.rs
@@ -1,5 +1,5 @@
 //! An implementation that supports multiple simple fungible tokens.
-//! 
+//!
 //! Each token behaves similarly to the the single token from the Money,
 //! piece as both implement the `Fungible` trait.
 
@@ -90,12 +90,8 @@ impl SimpleConstraintChecker for SpendToken {
         input_data: &[DynamicallyTypedData],
         output_data: &[DynamicallyTypedData],
     ) -> Result<TransactionPriority, Self::Error> {
-        
         // Check that we are consuming at least one input
-        ensure!(
-            !input_data.is_empty(),
-            MultiTokenError::SpendingNothing
-        );
+        ensure!(!input_data.is_empty(), MultiTokenError::SpendingNothing);
 
         let mut token_id = None;
         let mut total_input_value: u128 = 0;
@@ -154,18 +150,12 @@ mod test {
 
     /// Helper function to create a new token of id 0
     fn token_0(value: u128) -> Token {
-        Token {
-            id: 0,
-            value,
-        }
+        Token { id: 0, value }
     }
 
     /// Helper function to create a new token of id 1
     fn token_1(value: u128) -> Token {
-        Token {
-            id: 1,
-            value,
-        }
+        Token { id: 1, value }
     }
 
     #[test]

--- a/tuxedo-template-runtime/src/multitoken.rs
+++ b/tuxedo-template-runtime/src/multitoken.rs
@@ -1,0 +1,288 @@
+//! An implementation that supports multiple simple fungible tokens.
+//! 
+//! Each token behaves similarly to the the single token from the Money,
+//! piece as both implement the `Fungible` trait.
+
+use parity_scale_codec::{Decode, Encode};
+use scale_info::TypeInfo;
+#[cfg(feature = "std")]
+use serde::{Deserialize, Serialize};
+use sp_runtime::transaction_validity::TransactionPriority;
+use sp_std::prelude::*;
+use tuxedo_core::{
+    dynamic_typing::{DynamicallyTypedData, UtxoData},
+    ensure, SimpleConstraintChecker,
+};
+
+/// The main constraint checker for the multitoken. It allows sending tokens of a single type.
+#[cfg_attr(
+    feature = "std",
+    derive(Serialize, Deserialize, parity_util_mem::MallocSizeOf)
+)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Encode, Decode, Hash, Debug, TypeInfo)]
+pub struct SpendToken;
+
+// Idea, we could have a spend-multi where tokens of all kinds can be passed in
+// and the input > output constraint is enforced for each token.
+
+/// A development constraint checker that allows minting tokens of a single type.
+#[cfg_attr(
+    feature = "std",
+    derive(Serialize, Deserialize, parity_util_mem::MallocSizeOf)
+)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Encode, Decode, Hash, Debug, TypeInfo)]
+pub struct MintToken;
+
+/// A single Token in the fungible multitoken system.
+/// We know what type of token this is at the type level through the generic const.
+#[cfg_attr(
+    feature = "std",
+    derive(Serialize, Deserialize, parity_util_mem::MallocSizeOf)
+)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Encode, Decode, Hash, Debug, TypeInfo)]
+pub struct Token {
+    /// The unique ID for this kind of token.
+    pub id: u8,
+    /// The value of this token.
+    pub value: u128,
+}
+
+impl UtxoData for Token {
+    const TYPE_ID: [u8; 4] = *b"tokn";
+}
+
+/// Errors that can occur when checking multimoney transactions.
+#[cfg_attr(
+    feature = "std",
+    derive(Serialize, Deserialize, parity_util_mem::MallocSizeOf)
+)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Encode, Decode, Hash, Debug, TypeInfo)]
+pub enum MultiTokenError {
+    /// Dynamic typing issue.
+    /// This error doesn't discriminate between badly typed inputs and outputs.
+    BadlyTyped,
+    /// The transaction attempts to consume inputs while minting. This is not allowed.
+    MintingWithInputs,
+    /// The transaction attempts to mint zero coins. This is not allowed.
+    MintingNothing,
+    /// The transaction attempts to spend without consuming any inputs.
+    /// Either the output value will exceed the input value, or if there are no outputs,
+    /// it is a waste of processing power, so it is not allowed.
+    SpendingNothing,
+    /// The value of the spent input coins is less than the value of the newly created
+    /// output coins. This would lead to money creation and is not allowed.
+    OutputsExceedInputs,
+    /// The value consumed or created by this transaction overflows the value type.
+    /// This could lead to problems like https://bitcointalk.org/index.php?topic=823.0
+    ValueOverflow,
+    /// The transaction attempted to create a coin with zero value. This is not allowed
+    /// because it wastes state space.
+    ZeroValueCoin,
+    /// This transaction contains tokens of different ids.
+    MixedTokenIDs,
+}
+
+impl SimpleConstraintChecker for SpendToken {
+    type Error = MultiTokenError;
+
+    fn check(
+        &self,
+        input_data: &[DynamicallyTypedData],
+        output_data: &[DynamicallyTypedData],
+    ) -> Result<TransactionPriority, Self::Error> {
+        
+        // Check that we are consuming at least one input
+        ensure!(
+            !input_data.is_empty(),
+            MultiTokenError::SpendingNothing
+        );
+
+        let mut token_id = None;
+        let mut total_input_value: u128 = 0;
+        let mut total_output_value: u128 = 0;
+
+        // Check that sum of input values < output values
+        // and every token is of the same id
+        for input in input_data {
+            let token = input
+                .extract::<Token>()
+                .map_err(|_| MultiTokenError::BadlyTyped)?;
+            if token_id.is_none() {
+                token_id = Some(token.id);
+            } else {
+                ensure!(token_id == Some(token.id), MultiTokenError::MixedTokenIDs);
+            }
+            total_input_value = total_input_value
+                .checked_add(token.value)
+                .ok_or(MultiTokenError::ValueOverflow)?;
+        }
+
+        for utxo in output_data {
+            let token = utxo
+                .extract::<Token>()
+                .map_err(|_| MultiTokenError::BadlyTyped)?;
+            ensure!(token.value > 0, MultiTokenError::ZeroValueCoin);
+            ensure!(token_id == Some(token.id), MultiTokenError::MixedTokenIDs);
+            total_output_value = total_output_value
+                .checked_add(token.value)
+                .ok_or(MultiTokenError::ValueOverflow)?;
+        }
+
+        ensure!(
+            total_output_value <= total_input_value,
+            MultiTokenError::OutputsExceedInputs
+        );
+
+        // Priority is based on how many token are burned
+        // Type stuff is kinda ugly. Maybe division would be better?
+        // TODO add a configuration item that specifies the relative priority
+        // for each transaction type.
+        let burned = total_input_value - total_output_value;
+        Ok(if burned < u64::max_value() as u128 {
+            burned as u64
+        } else {
+            u64::max_value()
+        })
+    }
+}
+
+/// Unit tests for the Money piece
+#[cfg(test)]
+mod test {
+    use super::*;
+    use tuxedo_core::dynamic_typing::testing::Bogus;
+
+    #[test]
+    fn spend_valid_transaction_work() {
+        let input_data = vec![Coin(5).into(), Coin(7).into()]; // total 12
+        let output_data = vec![Coin(10).into(), Coin(1).into()]; // total 11
+        let expected_priority = 1u64;
+
+        assert_eq!(
+            MoneyConstraintChecker::Spend.check(&input_data, &output_data),
+            Ok(expected_priority),
+        );
+    }
+
+    #[test]
+    fn spend_with_zero_value_output_fails() {
+        let input_data = vec![Coin(5).into(), Coin(7).into()]; // total 12
+        let output_data = vec![Coin(10).into(), Coin(1).into(), Coin(0).into()]; // total 1164;
+
+        assert_eq!(
+            MoneyConstraintChecker::Spend.check(&input_data, &output_data),
+            Err(MultiTokenError::ZeroValueCoin),
+        );
+    }
+
+    #[test]
+    fn spend_no_outputs_is_a_burn() {
+        let input_data = vec![Coin(5).into(), Coin(7).into()]; // total 12
+        let output_data = vec![];
+        let expected_priority = 12u64;
+
+        assert_eq!(
+            MoneyConstraintChecker::Spend.check(&input_data, &output_data),
+            Ok(expected_priority),
+        );
+    }
+
+    #[test]
+    fn spend_no_inputs_fails() {
+        let input_data = vec![];
+        let output_data = vec![Coin(10).into(), Coin(1).into()];
+
+        assert_eq!(
+            MoneyConstraintChecker::Spend.check(&input_data, &output_data),
+            Err(MultiTokenError::SpendingNothing),
+        );
+    }
+
+    #[test]
+    fn spend_wrong_input_type_fails() {
+        let input_data = vec![Bogus.into()];
+        let output_data = vec![Coin(10).into(), Coin(1).into()];
+
+        assert_eq!(
+            MoneyConstraintChecker::Spend.check(&input_data, &output_data),
+            Err(MultiTokenError::BadlyTyped),
+        );
+    }
+
+    #[test]
+    fn spend_wrong_output_type_fails() {
+        let input_data = vec![Coin(5).into(), Coin(7).into()]; // total 12
+        let output_data = vec![Bogus.into()];
+
+        assert_eq!(
+            MoneyConstraintChecker::Spend.check(&input_data, &output_data),
+            Err(MultiTokenError::BadlyTyped),
+        );
+    }
+
+    #[test]
+    fn spend_output_value_exceeds_input_value_fails() {
+        let input_data = vec![Coin(10).into(), Coin(1).into()]; // total 11
+        let output_data = vec![Coin(5).into(), Coin(7).into()]; // total 12
+
+        assert_eq!(
+            MoneyConstraintChecker::Spend.check(&input_data, &output_data),
+            Err(MultiTokenError::OutputsExceedInputs),
+        );
+    }
+
+    #[test]
+    fn mint_valid_transaction_works() {
+        let input_data = vec![];
+        let output_data = vec![Coin(10).into(), Coin(1).into()];
+
+        assert_eq!(
+            MoneyConstraintChecker::Mint.check(&input_data, &output_data),
+            Ok(0),
+        );
+    }
+
+    #[test]
+    fn mint_with_zero_value_output_fails() {
+        let input_data = vec![];
+        let output_data = vec![Coin(0).into()];
+
+        assert_eq!(
+            MoneyConstraintChecker::Mint.check(&input_data, &output_data),
+            Err(MultiTokenError::ZeroValueCoin),
+        );
+    }
+
+    #[test]
+    fn mint_with_inputs_fails() {
+        let input_data = vec![Coin(5).into()];
+        let output_data = vec![Coin(10).into(), Coin(1).into()];
+
+        assert_eq!(
+            MoneyConstraintChecker::Mint.check(&input_data, &output_data),
+            Err(MultiTokenError::MintingWithInputs),
+        );
+    }
+
+    #[test]
+    fn mint_with_no_outputs_fails() {
+        let input_data = vec![];
+        let output_data = vec![];
+
+        assert_eq!(
+            MoneyConstraintChecker::Mint.check(&input_data, &output_data),
+            Err(MultiTokenError::MintingNothing),
+        );
+    }
+
+    #[test]
+    fn mint_wrong_output_type_fails() {
+        let input_data = vec![];
+        let output_data = vec![Coin(10).into(), Bogus.into()];
+
+        assert_eq!(
+            MoneyConstraintChecker::Mint.check(&input_data, &output_data),
+            Err(MultiTokenError::BadlyTyped),
+        );
+    }
+}

--- a/wallet/src/money.rs
+++ b/wallet/src/money.rs
@@ -38,7 +38,7 @@ pub async fn spend_coins(
     let mut total_output_amount = 0;
     for amount in &args.output_amount {
         let output = Output {
-            payload: Coin::new(*amount).into(),
+            payload: Coin::<0>::new(*amount).into(),
             verifier: OuterVerifier::SigCheck(SigCheck {
                 owner_pubkey: args.recipient,
             }),
@@ -121,7 +121,7 @@ pub async fn spend_coins(
             tx_hash,
             index: i as u32,
         };
-        let amount = output.payload.extract::<Coin>()?.0;
+        let amount = output.payload.extract::<Coin<0>>()?.0;
 
         print!(
             "Created {:?} worth {amount}. ",
@@ -138,9 +138,9 @@ pub async fn spend_coins(
 pub async fn get_coin_from_storage(
     output_ref: &OutputRef,
     client: &HttpClient,
-) -> anyhow::Result<(Coin, OuterVerifier)> {
+) -> anyhow::Result<(Coin::<0>, OuterVerifier)> {
     let utxo = fetch_storage::<OuterVerifier>(output_ref, client).await?;
-    let coin_in_storage: Coin = utxo.payload.extract()?;
+    let coin_in_storage: Coin::<0> = utxo.payload.extract()?;
 
     Ok((coin_in_storage, utxo.verifier))
 }

--- a/wallet/src/money.rs
+++ b/wallet/src/money.rs
@@ -138,9 +138,9 @@ pub async fn spend_coins(
 pub async fn get_coin_from_storage(
     output_ref: &OutputRef,
     client: &HttpClient,
-) -> anyhow::Result<(Coin::<0>, OuterVerifier)> {
+) -> anyhow::Result<(Coin<0>, OuterVerifier)> {
     let utxo = fetch_storage::<OuterVerifier>(output_ref, client).await?;
-    let coin_in_storage: Coin::<0> = utxo.payload.extract()?;
+    let coin_in_storage: Coin<0> = utxo.payload.extract()?;
 
     Ok((coin_in_storage, utxo.verifier))
 }

--- a/wallet/src/sync.rs
+++ b/wallet/src/sync.rs
@@ -81,7 +81,7 @@ pub(crate) async fn init_from_genesis<F: Fn(&OuterVerifier) -> bool>(
 
     for (output, output_ref) in filtered_outputs_and_refs {
         // For now the wallet only supports simple coins, so skip anything else
-        let amount = match output.payload.extract::<Coin>() {
+        let amount = match output.payload.extract::<Coin<0>>() {
             Ok(Coin(amount)) => amount,
             Err(_) => continue,
         };
@@ -324,7 +324,7 @@ async fn apply_transaction<F: Fn(&OuterVerifier) -> bool>(
         .enumerate()
     {
         // For now the wallet only supports simple coins, so skip anything else
-        let amount = match output.payload.extract::<Coin>() {
+        let amount = match output.payload.extract::<Coin<0>>() {
             Ok(Coin(amount)) => amount,
             Err(_) => continue,
         };


### PR DESCRIPTION
This PR explores allowing multiple tokens in a single runtime... twice. That is, it explores two different designs for a multitoken tuxedo piece.

## Strongly Typed Design

This first design is included as a change to the existing money piece. It just adds a `<const ID: u8>` generic to the `Coin` type. This allows different tokens to be distinguished _at the type level_. You can never send the wrong kind of token because the type system won't allow it.

This design is nice for use in our upcoming DEX tutorial. I plan to make the DEX generic over the types of the two tokens in the trading pair. This design gives a dedicated type to each token which will work nicely.

One consequence (which my be desirable or not depending on application) is that the number of tokens in the runtime must be fixed at compile time. You must explicitly add the `MoneyConstraintChecker::<2>` to your outer checker for each and every token you plan to use.

## Dynamically Typed design

The second design is in the new multitoken piece. This is still based on the original money code, but takes a much different approach. It replaces the Coin struct with
```rust
pub struct Coin {
  pub id: u8,
  pub value: u128,
}
```

This allows tokens to be added and destroyed from the runtime at any moment and no fixed number is required.

However, there is still only a single type for all the tokens. This means that if we want to used this with our DEX, we will need to make run-time checks on the token id all over the place.

## Are both useful?

Perhaps both should be kept in the library as they may have slightly different use cases.