### PR TITLE
Add some missing docs

### DIFF
--- a/wallet/src/keystore.rs
+++ b/wallet/src/keystore.rs
@@ -34,7 +34,7 @@ pub fn insert_default_key_for_this_session(keystore: &LocalKeystore) -> anyhow::
 }
 
 /// Sign a given message with the private key that corresponds to the given public key.
-/// 
+///
 /// Returns an error if the keystore itself errors, or does not contain the requested key.
 pub fn sign_with(
     keystore: &LocalKeystore,
@@ -59,7 +59,7 @@ pub fn insert_key(keystore: &LocalKeystore, seed: &str) -> anyhow::Result<()> {
 
 /// Generate a new key from system entropy and insert it into the keystore, optionally
 /// protected by a password.
-/// 
+///
 /// TODO there is no password support when using keys later when signing.
 pub fn generate_key(keystore: &LocalKeystore, password: Option<String>) -> anyhow::Result<()> {
     let (pair, phrase, _) = Pair::generate_with_phrase(password.as_deref());

--- a/wallet/src/keystore.rs
+++ b/wallet/src/keystore.rs
@@ -33,6 +33,9 @@ pub fn insert_default_key_for_this_session(keystore: &LocalKeystore) -> anyhow::
     Ok(())
 }
 
+/// Sign a given message with the private key that corresponds to the given public key.
+/// 
+/// Returns an error if the keystore itself errors, or does not contain the requested key.
 pub fn sign_with(
     keystore: &LocalKeystore,
     public: &Public,
@@ -43,7 +46,7 @@ pub fn sign_with(
         .ok_or(anyhow!("Key doesn't exist in keystore"))
 }
 
-/// Docs TODO
+/// Insert the private key associated with the given seed into the keystore for later use.
 pub fn insert_key(keystore: &LocalKeystore, seed: &str) -> anyhow::Result<()> {
     // We need to provide a public key to the keystore manually, so let's calculate it.
     let public_key = Pair::from_phrase(seed, None)?.0.public();
@@ -54,7 +57,10 @@ pub fn insert_key(keystore: &LocalKeystore, seed: &str) -> anyhow::Result<()> {
     Ok(())
 }
 
-/// Docs TODO
+/// Generate a new key from system entropy and insert it into the keystore, optionally
+/// protected by a password.
+/// 
+/// TODO there is no password support when using keys later when signing.
 pub fn generate_key(keystore: &LocalKeystore, password: Option<String>) -> anyhow::Result<()> {
     let (pair, phrase, _) = Pair::generate_with_phrase(password.as_deref());
     println!("Generated public key is {:?}", pair.public());


### PR DESCRIPTION
Simple PR to add missing doc comments to three functions in the wallet's keystore file