### PR TITLE
Update dockerfile to match Substrate's

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -10,7 +10,6 @@ on:
   push:
     branches:
       - main
-      - docker-ci-fix-hopefully
     tags:
       - '**'
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -10,6 +10,7 @@ on:
   push:
     branches:
       - main
+      - docker-ci-fix-hopefully
     tags:
       - '**'
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@
 # For the build stage, we use an image provided by Parity
 FROM docker.io/paritytech/ci-linux:production as builder
 WORKDIR /node-template
-COPY . .
+COPY . /node-template
 RUN cargo build --locked --release 
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # This is a multi-stage docker file. See https://docs.docker.com/build/building/multi-stage/
 # for details about this pattern.
-# It is largely copied from the Substrate node template
-# https://github.com/substrate-developer-hub/substrate-node-template/blob/main/Dockerfile
+# It is largely copied from Substrate
+# https://github.com/paritytech/substrate/blob/master/docker/substrate_builder.Dockerfile
 
 # For the build stage, we use an image provided by Parity
 FROM docker.io/paritytech/ci-linux:production as builder


### PR DESCRIPTION
Docker CI normally only runs on `main`. When I merged the aggregation macros PR, it failed on main. I reran a few times over the next few days and it is still failing. IDK why. The log output sounds like the wasm32-unknown-unknown target isn't installed, but it is running in a parity builder image. It is still recommended in the official Substrate repo.

Although the docs around that docker setup have changed a bit. They got removed from the node template repo, but still exist in the main Substrate repo. IDK if that is related to our now-failing CI. I've updated the links in any case.