### PR TITLE
Another multisig test

### DIFF
--- a/tuxedo-core/src/verifier.rs
+++ b/tuxedo-core/src/verifier.rs
@@ -253,6 +253,32 @@ mod test {
     }
 
     #[test]
+    fn threshold_multisig_extra_sigs_still_passes() {
+        let threshold = 2;
+        let pairs = generate_n_pairs(threshold + 1);
+
+        let signatories: Vec<H256> = pairs.iter().map(|p| H256::from(p.public())).collect();
+
+        let simplified_tx = b"hello_world".as_slice();
+        let sigs: Vec<_> = pairs
+            .iter()
+            .enumerate()
+            .map(|(i, p)| SignatureAndIndex {
+                signature: p.sign(simplified_tx),
+                index: i.try_into().unwrap(),
+            })
+            .collect();
+
+        let redeemer: &[u8] = &sigs.encode()[..];
+        let threshold_multisig = ThresholdMultiSignature {
+            threshold,
+            signatories,
+        };
+
+        assert!(!threshold_multisig.verify(simplified_tx, redeemer));
+    }
+
+    #[test]
     fn threshold_multisig_replay_sig_attack_fails() {
         let threshold = 2;
         let pairs = generate_n_pairs(threshold);

--- a/tuxedo-core/src/verifier.rs
+++ b/tuxedo-core/src/verifier.rs
@@ -275,7 +275,7 @@ mod test {
             signatories,
         };
 
-        assert!(!threshold_multisig.verify(simplified_tx, redeemer));
+        assert!(threshold_multisig.verify(simplified_tx, redeemer));
     }
 
     #[test]


### PR DESCRIPTION
When I was recently preparing the Substrate update in #67, I was briefly confused about the tests on the `ThresholdMultisig`. Once I read the tests carefully, I understood them and quickly got them passing.

However, I noticed that there was not a test for the case where the redeemer contains _more than enough_ valid signatures. This PR adds a single test for when there is a 2/3 multisig, and the redeemer contains valid sigs for _all three_ signatories even though only two are required. I expected this case to still successfully verify, but it seems it is not.

@coax1d is this the behavior you expected?