### PR TITLE
Opaque Extrinsics

### DIFF
--- a/tuxedo-core/src/dynamic_typing.rs
+++ b/tuxedo-core/src/dynamic_typing.rs
@@ -53,10 +53,7 @@ use sp_std::vec::Vec;
 
 /// A piece of encoded data with a type id associated
 /// Strongly typed data can be extracted
-#[cfg_attr(
-    feature = "std",
-    derive(Serialize, Deserialize, parity_util_mem::MallocSizeOf)
-)]
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 #[derive(Encode, Decode, Debug, PartialEq, Eq, Clone)]
 pub struct DynamicallyTypedData {
     pub data: Vec<u8>,

--- a/tuxedo-core/src/types.rs
+++ b/tuxedo-core/src/types.rs
@@ -35,10 +35,7 @@ pub struct OutputRef {
 ///
 /// In the future, there may be additional notions of peeks (inputs that are not consumed)
 /// and evictions (inputs that are forcefully consumed.)
-#[cfg_attr(
-    feature = "std",
-    derive(Serialize, Deserialize, parity_util_mem::MallocSizeOf)
-)]
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 #[derive(Encode, Decode, Debug, PartialEq, Eq, Clone)]
 pub struct Transaction<V, C> {
     pub inputs: Vec<Input>,
@@ -69,10 +66,7 @@ impl<V, C> Extrinsic for Transaction<V, C> {
 }
 
 /// A reference the a utxo that will be consumed along with proof that it may be consumed
-#[cfg_attr(
-    feature = "std",
-    derive(Serialize, Deserialize, parity_util_mem::MallocSizeOf)
-)]
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 #[derive(Encode, Decode, Debug, PartialEq, Eq, Clone)]
 pub struct Input {
     /// a reference to the output being consumed
@@ -104,10 +98,7 @@ pub type DispatchResult<VerifierError> = Result<(), UtxoError<VerifierError>>;
 /// the verifier is checked, strongly typed data will be extracted and passed to the constraint checker.
 /// In a cryptocurrency, the data represents a single coin. In Tuxedo, the type of
 /// the contained data is generic.
-#[cfg_attr(
-    feature = "std",
-    derive(Serialize, Deserialize, parity_util_mem::MallocSizeOf)
-)]
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 #[derive(Encode, Decode, Debug, PartialEq, Eq, Clone)]
 pub struct Output<V> {
     pub payload: DynamicallyTypedData,

--- a/tuxedo-core/src/types.rs
+++ b/tuxedo-core/src/types.rs
@@ -9,10 +9,7 @@ use sp_runtime::traits::Extrinsic;
 use sp_std::vec::Vec;
 
 /// A reference to a output that is expected to exist in the state.
-#[cfg_attr(
-    feature = "std",
-    derive(Serialize, Deserialize, parity_util_mem::MallocSizeOf)
-)]
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 #[derive(Encode, Decode, Debug, PartialEq, Eq, Clone)]
 pub struct OutputRef {
     /// A hash of the transaction that created this output
@@ -36,7 +33,7 @@ pub struct OutputRef {
 /// In the future, there may be additional notions of peeks (inputs that are not consumed)
 /// and evictions (inputs that are forcefully consumed.)
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
-#[derive(Encode, Decode, Debug, PartialEq, Eq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub struct Transaction<V, C> {
     pub inputs: Vec<Input>,
     //Todo peeks: Vec<Input>,
@@ -44,10 +41,8 @@ pub struct Transaction<V, C> {
     pub checker: C,
 }
 
-// Trying Kian's advice as far as I remember it. We manually implement serialize and deserialize for the transaction type
-// so that it can be serialized to/from the same bytes as an opaque Vec<u8>.
-// Stealing this code from Andrew's PBA solution:
-// https://github.com/Polkadot-Blockchain-Academy/frameless-node-template--master/blob/andrew_ungraded_solution/frameless-runtime/src/lib.rs#L127-L144
+// Manually implement Encode and Decode for the Transaction type
+// so that its encoding is the same as an opaque Vec<u8>.
 impl<V: Encode, C: Encode> Encode for Transaction<V, C> {
     fn encode_to<T: parity_scale_codec::Output + ?Sized>(&self, dest: &mut T) {
         let inputs = self.inputs.encode();
@@ -120,7 +115,7 @@ pub enum UtxoError<ConstraintCheckerError> {
     DuplicateInput,
     /// This transaction defines an output that already existed in the UTXO set
     PreExistingOutput,
-    /// The contraint checker errored.
+    /// The constraint checker errored.
     ConstraintCheckerError(ConstraintCheckerError),
     /// The Verifier errored.
     /// TODO determine whether it is useful to relay an inner error from the verifier.

--- a/tuxedo-core/src/verifier.rs
+++ b/tuxedo-core/src/verifier.rs
@@ -24,10 +24,7 @@ pub trait Verifier: Debug + Encode + Decode + Clone {
 }
 
 /// A typical verifier that checks an sr25519 signature
-#[cfg_attr(
-    feature = "std",
-    derive(Serialize, Deserialize, parity_util_mem::MallocSizeOf)
-)]
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 #[derive(Encode, Decode, Debug, PartialEq, Eq, Clone)]
 pub struct SigCheck {
     pub owner_pubkey: H256,
@@ -45,10 +42,7 @@ impl Verifier for SigCheck {
 }
 
 /// A simple verifier that allows anyone to consume an output at any time
-#[cfg_attr(
-    feature = "std",
-    derive(Serialize, Deserialize, parity_util_mem::MallocSizeOf)
-)]
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 #[derive(Encode, Decode, Debug, PartialEq, Eq, Clone)]
 pub struct UpForGrabs;
 
@@ -62,10 +56,7 @@ impl Verifier for UpForGrabs {
 /// guarded by this verifier. A valid redeemer must supply valid signatures by at least
 /// `threshold` of the signatories. If the threshold is greater than the number of signatories
 /// the input can never be consumed.
-#[cfg_attr(
-    feature = "std",
-    derive(Serialize, Deserialize, parity_util_mem::MallocSizeOf)
-)]
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 #[derive(Encode, Decode, Debug, PartialEq, Eq, Clone)]
 pub struct ThresholdMultiSignature {
     /// The minimum number of valid signatures needed to consume this input

--- a/tuxedo-template-runtime/src/amoeba.rs
+++ b/tuxedo-template-runtime/src/amoeba.rs
@@ -18,10 +18,7 @@ use tuxedo_core::{
 };
 
 /// An amoeba tracked by our simple Amoeba APP
-#[cfg_attr(
-    feature = "std",
-    derive(Serialize, Deserialize, parity_util_mem::MallocSizeOf)
-)]
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 #[derive(Encode, Decode, Debug, PartialEq, Eq, Clone)]
 pub struct AmoebaDetails {
     /// How many generations after the original Eve Amoeba this one is.
@@ -77,10 +74,7 @@ pub enum ConstraintCheckerError {
 /// 1. There is exactly one mother amoeba.
 /// 2. There are exactly two daughter amoebas
 /// 3. Each Daughter amoeba has a generation one higher than its mother.
-#[cfg_attr(
-    feature = "std",
-    derive(Serialize, Deserialize, parity_util_mem::MallocSizeOf)
-)]
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 #[derive(Encode, Decode, Debug, PartialEq, Eq, Clone)]
 pub struct AmoebaMitosis;
 
@@ -138,10 +132,7 @@ impl SimpleConstraintChecker for AmoebaMitosis {
 ///
 /// Any amoeba can be killed by providing it as the sole input to this constraint checker. No
 /// new outputs are ever created.
-#[cfg_attr(
-    feature = "std",
-    derive(Serialize, Deserialize, parity_util_mem::MallocSizeOf)
-)]
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 #[derive(Encode, Decode, Debug, PartialEq, Eq, Clone)]
 pub struct AmoebaDeath;
 
@@ -180,10 +171,7 @@ impl SimpleConstraintChecker for AmoebaDeath {
 ///
 /// A new amoeba can be created by providing it as the sole output to this constraint checker. No
 /// inputs are ever consumed.
-#[cfg_attr(
-    feature = "std",
-    derive(Serialize, Deserialize, parity_util_mem::MallocSizeOf)
-)]
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 #[derive(Encode, Decode, Debug, PartialEq, Eq, Clone)]
 pub struct AmoebaCreation;
 

--- a/tuxedo-template-runtime/src/kitties.rs
+++ b/tuxedo-template-runtime/src/kitties.rs
@@ -30,17 +30,11 @@ use tuxedo_core::{
     ensure, SimpleConstraintChecker,
 };
 
-#[cfg_attr(
-    feature = "std",
-    derive(Serialize, Deserialize, parity_util_mem::MallocSizeOf)
-)]
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Encode, Decode, Hash, Debug, TypeInfo)]
 pub struct FreeKittyConstraintChecker;
 
-#[cfg_attr(
-    feature = "std",
-    derive(Serialize, Deserialize, parity_util_mem::MallocSizeOf)
-)]
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 #[derive(PartialEq, Eq, PartialOrd, Ord, Default, Clone, Encode, Decode, Hash, Debug, TypeInfo)]
 pub enum DadKittyStatus {
     #[default]
@@ -48,10 +42,7 @@ pub enum DadKittyStatus {
     Tired,
 }
 
-#[cfg_attr(
-    feature = "std",
-    derive(Serialize, Deserialize, parity_util_mem::MallocSizeOf)
-)]
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 #[derive(PartialEq, Eq, PartialOrd, Ord, Default, Clone, Encode, Decode, Hash, Debug, TypeInfo)]
 pub enum MomKittyStatus {
     #[default]
@@ -59,10 +50,7 @@ pub enum MomKittyStatus {
     HadBirthRecently,
 }
 
-#[cfg_attr(
-    feature = "std",
-    derive(Serialize, Deserialize, parity_util_mem::MallocSizeOf)
-)]
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Encode, Decode, Hash, Debug, TypeInfo)]
 pub enum Parent {
     Mom(MomKittyStatus),
@@ -75,17 +63,11 @@ impl Default for Parent {
     }
 }
 
-#[cfg_attr(
-    feature = "std",
-    derive(Serialize, Deserialize, parity_util_mem::MallocSizeOf)
-)]
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 #[derive(PartialEq, Eq, PartialOrd, Ord, Default, Clone, Encode, Decode, Hash, Debug, TypeInfo)]
 pub struct KittyDNA(H256);
 
-#[cfg_attr(
-    feature = "std",
-    derive(Serialize, Deserialize, parity_util_mem::MallocSizeOf)
-)]
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Encode, Decode, Hash, Debug, TypeInfo)]
 pub struct KittyData {
     pub parent: Parent,
@@ -109,10 +91,7 @@ impl UtxoData for KittyData {
     const TYPE_ID: [u8; 4] = *b"Kitt";
 }
 
-#[cfg_attr(
-    feature = "std",
-    derive(Serialize, Deserialize, parity_util_mem::MallocSizeOf)
-)]
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Encode, Decode, Hash, Debug, TypeInfo)]
 pub enum ConstraintCheckerError {
     /// Dynamic typing issue.

--- a/tuxedo-template-runtime/src/lib.rs
+++ b/tuxedo-template-runtime/src/lib.rs
@@ -48,12 +48,9 @@ use tuxedo_core::types::OutputRef;
 /// to even the core data structures.
 pub mod opaque {
     use super::*;
-    // TODO: eventually you will have to change this.
-    type OpaqueExtrinsic = Transaction;
-    // type OpaqueExtrinsic = Vec<u8>;
+    // type OpaqueExtrinsic = Transaction;
+    type OpaqueExtrinsic = sp_runtime::OpaqueExtrinsic;
 
-    /// Opaque block header type.
-    pub type Header = sp_runtime::generic::Header<BlockNumber, BlakeTwo256>;
     /// Opaque block type.
     pub type Block = sp_runtime::generic::Block<Header, OpaqueExtrinsic>;
 
@@ -188,10 +185,7 @@ const BLOCK_TIME: u64 = 3000;
 
 /// A verifier checks that an individual input can be consumed. For example that it is signed properly
 /// To begin playing, we will have two kinds. A simple signature check, and an anyone-can-consume check.
-#[cfg_attr(
-    feature = "std",
-    derive(Serialize, Deserialize, parity_util_mem::MallocSizeOf)
-)]
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 #[derive(Encode, Decode, Debug, PartialEq, Eq, Clone)]
 #[tuxedo_verifier]
 pub enum OuterVerifier {
@@ -207,10 +201,7 @@ pub enum OuterVerifier {
 /// A constraint checker is a piece of logic that can be used to check a transaction.
 /// For any given Tuxedo runtime there is a finite set of such constraint checkers.
 /// For example, this may check that input token values exceed output token values.
-#[cfg_attr(
-    feature = "std",
-    derive(Serialize, Deserialize, parity_util_mem::MallocSizeOf)
-)]
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 #[derive(Encode, Decode, Debug, PartialEq, Eq, Clone)]
 #[tuxedo_constraint_checker]
 pub enum OuterConstraintChecker {

--- a/tuxedo-template-runtime/src/lib.rs
+++ b/tuxedo-template-runtime/src/lib.rs
@@ -48,11 +48,9 @@ use tuxedo_core::types::OutputRef;
 /// to even the core data structures.
 pub mod opaque {
     use super::*;
-    // type OpaqueExtrinsic = Transaction;
-    type OpaqueExtrinsic = sp_runtime::OpaqueExtrinsic;
 
     /// Opaque block type.
-    pub type Block = sp_runtime::generic::Block<Header, OpaqueExtrinsic>;
+    pub type Block = sp_runtime::generic::Block<Header, sp_runtime::OpaqueExtrinsic>;
 
     // This part is necessary for generating session keys in the runtime
     impl_opaque_keys! {

--- a/tuxedo-template-runtime/src/money.rs
+++ b/tuxedo-template-runtime/src/money.rs
@@ -14,10 +14,7 @@ use tuxedo_core::{
 // use log::info;
 
 /// The main constraint checker for the money piece. Allows spending and minting tokens.
-#[cfg_attr(
-    feature = "std",
-    derive(Serialize, Deserialize, parity_util_mem::MallocSizeOf)
-)]
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Encode, Decode, Hash, Debug, TypeInfo)]
 pub enum MoneyConstraintChecker {
     /// A typical spend transaction where some coins are consumed and others are created.
@@ -32,10 +29,7 @@ pub enum MoneyConstraintChecker {
 
 /// A single coin in the fungible money system.
 /// A new-type wrapper around a `u128` value.
-#[cfg_attr(
-    feature = "std",
-    derive(Serialize, Deserialize, parity_util_mem::MallocSizeOf)
-)]
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Encode, Decode, Hash, Debug, TypeInfo)]
 pub struct Coin(pub u128);
 
@@ -50,10 +44,7 @@ impl UtxoData for Coin {
 }
 
 /// Errors that can occur when checking money transactions.
-#[cfg_attr(
-    feature = "std",
-    derive(Serialize, Deserialize, parity_util_mem::MallocSizeOf)
-)]
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Encode, Decode, Hash, Debug, TypeInfo)]
 pub enum ConstraintCheckerError {
     /// Dynamic typing issue.

--- a/tuxedo-template-runtime/src/poe.rs
+++ b/tuxedo-template-runtime/src/poe.rs
@@ -26,10 +26,7 @@ use tuxedo_core::{
 };
 
 // Notice this type doesn't have to be public. Cool.
-#[cfg_attr(
-    feature = "std",
-    derive(Serialize, Deserialize, parity_util_mem::MallocSizeOf)
-)]
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 #[derive(Encode, Decode, Debug, PartialEq, Eq, Clone)]
 struct ClaimData {
     /// The hash of the data whose existence is being proven.
@@ -43,10 +40,7 @@ impl UtxoData for ClaimData {
 }
 
 /// Errors that can occur when checking PoE Transactions
-#[cfg_attr(
-    feature = "std",
-    derive(Serialize, Deserialize, parity_util_mem::MallocSizeOf)
-)]
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 #[derive(Encode, Decode, Debug, PartialEq, Eq, Clone)]
 pub enum ConstraintCheckerError {
     // Ughhh again with these common errors.
@@ -70,10 +64,7 @@ pub enum ConstraintCheckerError {
 /// This constraint checker allows the creation of many claims in a single operation
 /// It also allows the creation of zero claims, although such a transaction is useless and is simply a
 /// waste of caller fees.
-#[cfg_attr(
-    feature = "std",
-    derive(Serialize, Deserialize, parity_util_mem::MallocSizeOf)
-)]
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 #[derive(Encode, Decode, Debug, PartialEq, Eq, Clone)]
 pub struct PoeClaim;
 
@@ -116,10 +107,7 @@ impl SimpleConstraintChecker for PoeClaim {
 /// A constraint checker to revoke claims.
 ///
 /// Like the creation constraint checker, this allows batch revocation.
-#[cfg_attr(
-    feature = "std",
-    derive(Serialize, Deserialize, parity_util_mem::MallocSizeOf)
-)]
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 #[derive(Encode, Decode, Debug, PartialEq, Eq, Clone)]
 pub struct PoeRevoke;
 
@@ -158,10 +146,7 @@ impl SimpleConstraintChecker for PoeRevoke {
 /// the verifier logic? This is a concrete case where the constraint checker verifier separation is not ideal.
 /// Another, weaker example, is when trying o implement something like sudo. Where we want a signature,
 /// but we want to authorized signer to come from the a different part of state.
-#[cfg_attr(
-    feature = "std",
-    derive(Serialize, Deserialize, parity_util_mem::MallocSizeOf)
-)]
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 #[derive(Encode, Decode, Debug, PartialEq, Eq, Clone)]
 pub struct PoeDispute;
 

--- a/tuxedo-template-runtime/src/runtime_upgrade.rs
+++ b/tuxedo-template-runtime/src/runtime_upgrade.rs
@@ -23,10 +23,7 @@ use tuxedo_core::{
 };
 
 /// A reference to a runtime wasm blob. It is just a hash.
-#[cfg_attr(
-    feature = "std",
-    derive(Serialize, Deserialize, parity_util_mem::MallocSizeOf)
-)]
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 #[derive(Encode, Decode, Debug, PartialEq, Eq, Clone)]
 struct RuntimeRef {
     hash: [u8; 32],
@@ -65,10 +62,7 @@ pub enum ConstraintCheckerError {
 /// This constraint checker is somewhat non-standard in that it has a side-effect that
 /// writes the full wasm code to the well-known `:code` storage key. This is
 /// necessary to satisfy Substrate's assumptions that this will happen.
-#[cfg_attr(
-    feature = "std",
-    derive(Serialize, Deserialize, parity_util_mem::MallocSizeOf)
-)]
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 #[derive(Encode, Decode, Debug, PartialEq, Eq, Clone)]
 pub struct RuntimeUpgrade {
     full_wasm: Vec<u8>,


### PR DESCRIPTION
Solves #22 

I set out just trying to make the derives in the runtime look a little nicer. Ended up here. I do think they look nicer though, so mission accomplished.

This PR changes the encoding of the `tuxedo_core::Transaction<V, C>` slightly. It prepends the previous derived encoding with the length of that encoding in bytes. The whole point of this is that runtime's can then use the `OpaqueExtrinsic` type so the client doesn't need to know the details and runtime upgrades are more useful.

The actual encoding and decoding logic is inspired by @coax1d's PBA example solution https://github.com/Polkadot-Blockchain-Academy/frameless-node-template--master/blob/andrew_ungraded_solution/frameless-runtime/src/lib.rs#L127-L144. But I'm not so sure the decoding is right over there. I don't see it skipping the prepended compact length anywhere. I added that here and it seems to work fine.