### PR TITLE
Instantiable Money Piece

### DIFF
--- a/tuxedo-core/src/lib.rs
+++ b/tuxedo-core/src/lib.rs
@@ -11,6 +11,7 @@ mod executive;
 
 pub mod constraint_checker;
 pub mod support_macros;
+pub mod traits;
 pub mod types;
 pub mod utxo_set;
 pub mod verifier;

--- a/tuxedo-core/src/traits.rs
+++ b/tuxedo-core/src/traits.rs
@@ -1,0 +1,12 @@
+//! General-purpose runtime traits for describing common types of on-chain logic.
+//! Tuxedo piece implementations may loosely couple through these traits.
+
+/// A trait for UTXOs that can act like coins, or bank notes.
+pub trait Cash {
+    /// Get the value of this token.
+    fn value(&self) -> u128;
+
+    /// A 1-byte unique identifier for this coin.
+    /// Might need more than 1 byte eventually...
+    const ID: u8;
+}

--- a/tuxedo-template-runtime/src/lib.rs
+++ b/tuxedo-template-runtime/src/lib.rs
@@ -48,9 +48,14 @@ use tuxedo_core::types::OutputRef;
 /// to even the core data structures.
 pub mod opaque {
     use super::*;
+    // TODO: eventually you will have to change this.
+    type OpaqueExtrinsic = Transaction;
+    // type OpaqueExtrinsic = Vec<u8>;
 
+    /// Opaque block header type.
+    pub type Header = sp_runtime::generic::Header<BlockNumber, BlakeTwo256>;
     /// Opaque block type.
-    pub type Block = sp_runtime::generic::Block<Header, sp_runtime::OpaqueExtrinsic>;
+    pub type Block = sp_runtime::generic::Block<Header, OpaqueExtrinsic>;
 
     // This part is necessary for generating session keys in the runtime
     impl_opaque_keys! {
@@ -119,7 +124,7 @@ impl Default for GenesisConfig {
                     }),
                     payload: DynamicallyTypedData {
                         data: 100u128.encode(),
-                        type_id: <money::Coin as UtxoData>::TYPE_ID,
+                        type_id: <money::Coin<0> as UtxoData>::TYPE_ID,
                     },
                 },
                 Output {
@@ -129,7 +134,7 @@ impl Default for GenesisConfig {
                     }),
                     payload: DynamicallyTypedData {
                         data: 100u128.encode(),
-                        type_id: <money::Coin as UtxoData>::TYPE_ID,
+                        type_id: <money::Coin<0> as UtxoData>::TYPE_ID,
                     },
                 },
             ],
@@ -204,7 +209,7 @@ pub enum OuterVerifier {
 #[tuxedo_constraint_checker]
 pub enum OuterConstraintChecker {
     /// Checks monetary transactions in a basic fungible cryptocurrency
-    Money(money::MoneyConstraintChecker),
+    Money(money::MoneyConstraintChecker<0>),
     /// Checks Free Kitty transactions
     FreeKittyConstraintChecker(kitties::FreeKittyConstraintChecker),
     /// Checks that an amoeba can split into two new amoebas
@@ -451,7 +456,7 @@ mod tests {
                 }),
                 payload: DynamicallyTypedData {
                     data: 100u128.encode(),
-                    type_id: <money::Coin as UtxoData>::TYPE_ID,
+                    type_id: <money::Coin<0> as UtxoData>::TYPE_ID,
                 },
             };
 
@@ -486,7 +491,7 @@ mod tests {
                 }),
                 payload: DynamicallyTypedData {
                     data: 100u128.encode(),
-                    type_id: <money::Coin as UtxoData>::TYPE_ID,
+                    type_id: <money::Coin<0> as UtxoData>::TYPE_ID,
                 },
             };
 

--- a/tuxedo-template-runtime/src/lib.rs
+++ b/tuxedo-template-runtime/src/lib.rs
@@ -48,14 +48,9 @@ use tuxedo_core::types::OutputRef;
 /// to even the core data structures.
 pub mod opaque {
     use super::*;
-    // TODO: eventually you will have to change this.
-    type OpaqueExtrinsic = Transaction;
-    // type OpaqueExtrinsic = Vec<u8>;
 
-    /// Opaque block header type.
-    pub type Header = sp_runtime::generic::Header<BlockNumber, BlakeTwo256>;
     /// Opaque block type.
-    pub type Block = sp_runtime::generic::Block<Header, OpaqueExtrinsic>;
+    pub type Block = sp_runtime::generic::Block<Header, sp_runtime::OpaqueExtrinsic>;
 
     // This part is necessary for generating session keys in the runtime
     impl_opaque_keys! {

--- a/tuxedo-template-runtime/src/money.rs
+++ b/tuxedo-template-runtime/src/money.rs
@@ -8,21 +8,10 @@ use sp_runtime::transaction_validity::TransactionPriority;
 use sp_std::prelude::*;
 use tuxedo_core::{
     dynamic_typing::{DynamicallyTypedData, UtxoData},
-    ensure, SimpleConstraintChecker,
+    ensure,
+    traits::Cash,
+    SimpleConstraintChecker,
 };
-
-/// TODO This should live somewhere analogous to frame support, not right here in the money piece.
-/// But this is where it is for now.
-///
-/// A trait for UTXOs that can act like coins, or bank notes.
-pub trait Cash {
-    /// Get the value of this token.
-    fn value(&self) -> u128;
-
-    /// A 1-byte unique identifier for this coin.
-    /// Might need more than 1 byte eventually...
-    const ID: u8;
-}
 
 impl<const ID: u8> Cash for Coin<ID> {
     fn value(&self) -> u128 {

--- a/tuxedo-template-runtime/src/money.rs
+++ b/tuxedo-template-runtime/src/money.rs
@@ -24,10 +24,7 @@ impl<const ID: u8> Cash for Coin<ID> {
 // use log::info;
 
 /// The main constraint checker for the money piece. Allows spending and minting tokens.
-#[cfg_attr(
-    feature = "std",
-    derive(Serialize, Deserialize, parity_util_mem::MallocSizeOf)
-)]
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Encode, Decode, Hash, Debug, TypeInfo)]
 pub enum MoneyConstraintChecker<const ID: u8> {
     /// A typical spend transaction where some coins are consumed and others are created.
@@ -42,10 +39,7 @@ pub enum MoneyConstraintChecker<const ID: u8> {
 
 /// A single coin in the fungible money system.
 /// A new-type wrapper around a `u128` value.
-#[cfg_attr(
-    feature = "std",
-    derive(Serialize, Deserialize, parity_util_mem::MallocSizeOf)
-)]
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Encode, Decode, Hash, Debug, TypeInfo)]
 pub struct Coin<const ID: u8>(pub u128);
 
@@ -60,10 +54,7 @@ impl<const ID: u8> UtxoData for Coin<ID> {
 }
 
 /// Errors that can occur when checking money transactions.
-#[cfg_attr(
-    feature = "std",
-    derive(Serialize, Deserialize, parity_util_mem::MallocSizeOf)
-)]
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Encode, Decode, Hash, Debug, TypeInfo)]
 pub enum ConstraintCheckerError {
     /// Dynamic typing issue.

--- a/tuxedo-template-runtime/src/money.rs
+++ b/tuxedo-template-runtime/src/money.rs
@@ -188,7 +188,7 @@ mod test {
             Coin::<0>(10).into(),
             Coin::<0>(1).into(),
             Coin::<0>(0).into(),
-        ]; // total 1164;
+        ]; // total 11
 
         assert_eq!(
             MoneyConstraintChecker::<0>::Spend.check(&input_data, &output_data),

--- a/tuxedo-template-runtime/src/money.rs
+++ b/tuxedo-template-runtime/src/money.rs
@@ -11,12 +11,36 @@ use tuxedo_core::{
     ensure, SimpleConstraintChecker,
 };
 
+/// TODO This should live somewhere analogous to frame support, not right here in the money piece.
+/// But this is where it is for now.
+///
+/// A trait for UTXOs that can act like coins, or bank notes.
+pub trait Cash {
+    /// Get the value of this token.
+    fn value(&self) -> u128;
+
+    /// A 1-byte unique identifier for this coin.
+    /// Might need more than 1 byte eventually...
+    const ID: u8;
+}
+
+impl<const ID: u8> Cash for Coin<ID> {
+    fn value(&self) -> u128 {
+        self.0
+    }
+
+    const ID: u8 = ID;
+}
+
 // use log::info;
 
 /// The main constraint checker for the money piece. Allows spending and minting tokens.
-#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
+#[cfg_attr(
+    feature = "std",
+    derive(Serialize, Deserialize, parity_util_mem::MallocSizeOf)
+)]
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Encode, Decode, Hash, Debug, TypeInfo)]
-pub enum MoneyConstraintChecker {
+pub enum MoneyConstraintChecker<const ID: u8> {
     /// A typical spend transaction where some coins are consumed and others are created.
     /// Input value must exceed output value. The difference is burned and reflected in the
     /// transaction's priority.
@@ -29,22 +53,28 @@ pub enum MoneyConstraintChecker {
 
 /// A single coin in the fungible money system.
 /// A new-type wrapper around a `u128` value.
-#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
+#[cfg_attr(
+    feature = "std",
+    derive(Serialize, Deserialize, parity_util_mem::MallocSizeOf)
+)]
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Encode, Decode, Hash, Debug, TypeInfo)]
-pub struct Coin(pub u128);
+pub struct Coin<const ID: u8>(pub u128);
 
-impl Coin {
+impl<const ID: u8> Coin<ID> {
     pub fn new(amt: u128) -> Self {
         Coin(amt)
     }
 }
 
-impl UtxoData for Coin {
-    const TYPE_ID: [u8; 4] = *b"coin";
+impl<const ID: u8> UtxoData for Coin<ID> {
+    const TYPE_ID: [u8; 4] = [b'c', b'o', b'i', ID];
 }
 
 /// Errors that can occur when checking money transactions.
-#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
+#[cfg_attr(
+    feature = "std",
+    derive(Serialize, Deserialize, parity_util_mem::MallocSizeOf)
+)]
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Encode, Decode, Hash, Debug, TypeInfo)]
 pub enum ConstraintCheckerError {
     /// Dynamic typing issue.
@@ -69,7 +99,7 @@ pub enum ConstraintCheckerError {
     ZeroValueCoin,
 }
 
-impl SimpleConstraintChecker for MoneyConstraintChecker {
+impl<const ID: u8> SimpleConstraintChecker for MoneyConstraintChecker<ID> {
     type Error = ConstraintCheckerError;
 
     fn check(
@@ -91,7 +121,7 @@ impl SimpleConstraintChecker for MoneyConstraintChecker {
                 // Check that sum of input values < output values
                 for input in input_data {
                     let utxo_value = input
-                        .extract::<Coin>()
+                        .extract::<Coin<ID>>()
                         .map_err(|_| ConstraintCheckerError::BadlyTyped)?
                         .0;
                     total_input_value = total_input_value
@@ -101,7 +131,7 @@ impl SimpleConstraintChecker for MoneyConstraintChecker {
 
                 for utxo in output_data {
                     let utxo_value = utxo
-                        .extract::<Coin>()
+                        .extract::<Coin<ID>>()
                         .map_err(|_| ConstraintCheckerError::BadlyTyped)?
                         .0;
                     ensure!(utxo_value > 0, ConstraintCheckerError::ZeroValueCoin);
@@ -140,7 +170,7 @@ impl SimpleConstraintChecker for MoneyConstraintChecker {
                 // Make sure the outputs are the right type
                 for utxo in output_data {
                     let utxo_value = utxo
-                        .extract::<Coin>()
+                        .extract::<Coin<ID>>()
                         .map_err(|_| ConstraintCheckerError::BadlyTyped)?
                         .0;
                     ensure!(utxo_value > 0, ConstraintCheckerError::ZeroValueCoin);
@@ -161,35 +191,39 @@ mod test {
 
     #[test]
     fn spend_valid_transaction_work() {
-        let input_data = vec![Coin(5).into(), Coin(7).into()]; // total 12
-        let output_data = vec![Coin(10).into(), Coin(1).into()]; // total 11
+        let input_data = vec![Coin::<0>(5).into(), Coin::<0>(7).into()]; // total 12
+        let output_data = vec![Coin::<0>(10).into(), Coin::<0>(1).into()]; // total 11
         let expected_priority = 1u64;
 
         assert_eq!(
-            MoneyConstraintChecker::Spend.check(&input_data, &output_data),
+            MoneyConstraintChecker::<0>::Spend.check(&input_data, &output_data),
             Ok(expected_priority),
         );
     }
 
     #[test]
     fn spend_with_zero_value_output_fails() {
-        let input_data = vec![Coin(5).into(), Coin(7).into()]; // total 12
-        let output_data = vec![Coin(10).into(), Coin(1).into(), Coin(0).into()]; // total 1164;
+        let input_data = vec![Coin::<0>(5).into(), Coin::<0>(7).into()]; // total 12
+        let output_data = vec![
+            Coin::<0>(10).into(),
+            Coin::<0>(1).into(),
+            Coin::<0>(0).into(),
+        ]; // total 1164;
 
         assert_eq!(
-            MoneyConstraintChecker::Spend.check(&input_data, &output_data),
+            MoneyConstraintChecker::<0>::Spend.check(&input_data, &output_data),
             Err(ConstraintCheckerError::ZeroValueCoin),
         );
     }
 
     #[test]
     fn spend_no_outputs_is_a_burn() {
-        let input_data = vec![Coin(5).into(), Coin(7).into()]; // total 12
+        let input_data = vec![Coin::<0>(5).into(), Coin::<0>(7).into()]; // total 12
         let output_data = vec![];
         let expected_priority = 12u64;
 
         assert_eq!(
-            MoneyConstraintChecker::Spend.check(&input_data, &output_data),
+            MoneyConstraintChecker::<0>::Spend.check(&input_data, &output_data),
             Ok(expected_priority),
         );
     }
@@ -197,10 +231,10 @@ mod test {
     #[test]
     fn spend_no_inputs_fails() {
         let input_data = vec![];
-        let output_data = vec![Coin(10).into(), Coin(1).into()];
+        let output_data = vec![Coin::<0>(10).into(), Coin::<0>(1).into()];
 
         assert_eq!(
-            MoneyConstraintChecker::Spend.check(&input_data, &output_data),
+            MoneyConstraintChecker::<0>::Spend.check(&input_data, &output_data),
             Err(ConstraintCheckerError::SpendingNothing),
         );
     }
@@ -208,32 +242,32 @@ mod test {
     #[test]
     fn spend_wrong_input_type_fails() {
         let input_data = vec![Bogus.into()];
-        let output_data = vec![Coin(10).into(), Coin(1).into()];
+        let output_data = vec![Coin::<0>(10).into(), Coin::<0>(1).into()];
 
         assert_eq!(
-            MoneyConstraintChecker::Spend.check(&input_data, &output_data),
+            MoneyConstraintChecker::<0>::Spend.check(&input_data, &output_data),
             Err(ConstraintCheckerError::BadlyTyped),
         );
     }
 
     #[test]
     fn spend_wrong_output_type_fails() {
-        let input_data = vec![Coin(5).into(), Coin(7).into()]; // total 12
+        let input_data = vec![Coin::<0>(5).into(), Coin::<0>(7).into()]; // total 12
         let output_data = vec![Bogus.into()];
 
         assert_eq!(
-            MoneyConstraintChecker::Spend.check(&input_data, &output_data),
+            MoneyConstraintChecker::<0>::Spend.check(&input_data, &output_data),
             Err(ConstraintCheckerError::BadlyTyped),
         );
     }
 
     #[test]
     fn spend_output_value_exceeds_input_value_fails() {
-        let input_data = vec![Coin(10).into(), Coin(1).into()]; // total 11
-        let output_data = vec![Coin(5).into(), Coin(7).into()]; // total 12
+        let input_data = vec![Coin::<0>(10).into(), Coin::<0>(1).into()]; // total 11
+        let output_data = vec![Coin::<0>(5).into(), Coin::<0>(7).into()]; // total 12
 
         assert_eq!(
-            MoneyConstraintChecker::Spend.check(&input_data, &output_data),
+            MoneyConstraintChecker::<0>::Spend.check(&input_data, &output_data),
             Err(ConstraintCheckerError::OutputsExceedInputs),
         );
     }
@@ -241,10 +275,10 @@ mod test {
     #[test]
     fn mint_valid_transaction_works() {
         let input_data = vec![];
-        let output_data = vec![Coin(10).into(), Coin(1).into()];
+        let output_data = vec![Coin::<0>(10).into(), Coin::<0>(1).into()];
 
         assert_eq!(
-            MoneyConstraintChecker::Mint.check(&input_data, &output_data),
+            MoneyConstraintChecker::<0>::Mint.check(&input_data, &output_data),
             Ok(0),
         );
     }
@@ -252,21 +286,21 @@ mod test {
     #[test]
     fn mint_with_zero_value_output_fails() {
         let input_data = vec![];
-        let output_data = vec![Coin(0).into()];
+        let output_data = vec![Coin::<0>(0).into()];
 
         assert_eq!(
-            MoneyConstraintChecker::Mint.check(&input_data, &output_data),
+            MoneyConstraintChecker::<0>::Mint.check(&input_data, &output_data),
             Err(ConstraintCheckerError::ZeroValueCoin),
         );
     }
 
     #[test]
     fn mint_with_inputs_fails() {
-        let input_data = vec![Coin(5).into()];
-        let output_data = vec![Coin(10).into(), Coin(1).into()];
+        let input_data = vec![Coin::<0>(5).into()];
+        let output_data = vec![Coin::<0>(10).into(), Coin::<0>(1).into()];
 
         assert_eq!(
-            MoneyConstraintChecker::Mint.check(&input_data, &output_data),
+            MoneyConstraintChecker::<0>::Mint.check(&input_data, &output_data),
             Err(ConstraintCheckerError::MintingWithInputs),
         );
     }
@@ -277,7 +311,7 @@ mod test {
         let output_data = vec![];
 
         assert_eq!(
-            MoneyConstraintChecker::Mint.check(&input_data, &output_data),
+            MoneyConstraintChecker::<0>::Mint.check(&input_data, &output_data),
             Err(ConstraintCheckerError::MintingNothing),
         );
     }
@@ -285,10 +319,10 @@ mod test {
     #[test]
     fn mint_wrong_output_type_fails() {
         let input_data = vec![];
-        let output_data = vec![Coin(10).into(), Bogus.into()];
+        let output_data = vec![Coin::<0>(10).into(), Bogus.into()];
 
         assert_eq!(
-            MoneyConstraintChecker::Mint.check(&input_data, &output_data),
+            MoneyConstraintChecker::<0>::Mint.check(&input_data, &output_data),
             Err(ConstraintCheckerError::BadlyTyped),
         );
     }

--- a/wallet/src/money.rs
+++ b/wallet/src/money.rs
@@ -38,7 +38,7 @@ pub async fn spend_coins(
     let mut total_output_amount = 0;
     for amount in &args.output_amount {
         let output = Output {
-            payload: Coin::new(*amount).into(),
+            payload: Coin::<0>::new(*amount).into(),
             verifier: OuterVerifier::SigCheck(SigCheck {
                 owner_pubkey: args.recipient,
             }),
@@ -121,7 +121,7 @@ pub async fn spend_coins(
             tx_hash,
             index: i as u32,
         };
-        let amount = output.payload.extract::<Coin>()?.0;
+        let amount = output.payload.extract::<Coin<0>>()?.0;
 
         print!(
             "Created {:?} worth {amount}. ",
@@ -138,9 +138,9 @@ pub async fn spend_coins(
 pub async fn get_coin_from_storage(
     output_ref: &OutputRef,
     client: &HttpClient,
-) -> anyhow::Result<(Coin, OuterVerifier)> {
+) -> anyhow::Result<(Coin<0>, OuterVerifier)> {
     let utxo = fetch_storage::<OuterVerifier>(output_ref, client).await?;
-    let coin_in_storage: Coin = utxo.payload.extract()?;
+    let coin_in_storage: Coin<0> = utxo.payload.extract()?;
 
     Ok((coin_in_storage, utxo.verifier))
 }

--- a/wallet/src/sync.rs
+++ b/wallet/src/sync.rs
@@ -81,7 +81,7 @@ pub(crate) async fn init_from_genesis<F: Fn(&OuterVerifier) -> bool>(
 
     for (output, output_ref) in filtered_outputs_and_refs {
         // For now the wallet only supports simple coins, so skip anything else
-        let amount = match output.payload.extract::<Coin>() {
+        let amount = match output.payload.extract::<Coin<0>>() {
             Ok(Coin(amount)) => amount,
             Err(_) => continue,
         };
@@ -324,7 +324,7 @@ async fn apply_transaction<F: Fn(&OuterVerifier) -> bool>(
         .enumerate()
     {
         // For now the wallet only supports simple coins, so skip anything else
-        let amount = match output.payload.extract::<Coin>() {
+        let amount = match output.payload.extract::<Coin<0>>() {
             Ok(Coin(amount)) => amount,
             Err(_) => continue,
         };


### PR DESCRIPTION
This PR is replacement for #69 with reduced scope. It also solves #17 by demonstrating that it was always possible :)

This PR extends the money piece to be generic over a `const u8` which is it's token id. The `Coin` type which implements `UtxoData` is also generic over this type so that different coins can be distinguished at the type level when they are pulled back out from storage.

It also introduces a trait called `Cash` which abstracts the notion of a fungible cash-like asset. The `Cash` trait also exposes the token id, although this design may change later.