### PR TITLE
Move pieces to individual crates in the wardrobe

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3966,6 +3966,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "money"
+version = "0.1.0"
+dependencies = [
+ "parity-scale-codec",
+ "scale-info",
+ "serde",
+ "sp-runtime",
+ "sp-std",
+ "tuxedo-core",
+]
+
+[[package]]
 name = "multiaddr"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8377,6 +8389,7 @@ version = "1.0.0-dev"
 dependencies = [
  "hex-literal",
  "log",
+ "money",
  "parity-scale-codec",
  "parity-util-mem",
  "scale-info",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "tuxedo-core",
     "tuxedo-core/aggregator",
     "wallet",
+    "wardrobe/money",
 ]
 [profile.release]
 panic = "unwind"

--- a/tuxedo-template-runtime/Cargo.toml
+++ b/tuxedo-template-runtime/Cargo.toml
@@ -34,8 +34,9 @@ sp-consensus-aura = { git = 'https://github.com/paritytech/substrate', tag = "mo
 sp-application-crypto = { git = 'https://github.com/paritytech/substrate', tag = "monthly-2023-05", default_features = false}
 sp-consensus-grandpa = { git = 'https://github.com/paritytech/substrate', tag = "monthly-2023-05", default_features = false}
 
-# Tuxedo Core
+# Tuxedo Core and Pieces
 tuxedo-core = { path = '../tuxedo-core', default-features = false }
+money = { path = '../wardrobe/money', default-features = false }
 
 [build-dependencies]
 substrate-wasm-builder = { git = "https://github.com/paritytech/substrate.git", tag = "monthly-2023-05" }
@@ -67,4 +68,5 @@ std = [
 	"sp-consensus-grandpa/std",
 
 	"tuxedo-core/std",
+	"money/std",
 ]

--- a/tuxedo-template-runtime/src/lib.rs
+++ b/tuxedo-template-runtime/src/lib.rs
@@ -1,3 +1,9 @@
+//! The Tuxedo Template Runtime is an example runtime that uses
+//! most of the pieces provided in the wardrobe.
+//! 
+//! Runtime developers wishing to get started with Tuxedo should
+//! consider copying this template.
+
 #![cfg_attr(not(feature = "std"), no_std)]
 
 #[cfg(feature = "std")]
@@ -30,7 +36,6 @@ use serde::{Deserialize, Serialize};
 
 pub mod amoeba;
 pub mod kitties;
-pub mod money;
 mod poe;
 mod runtime_upgrade;
 use tuxedo_core::{
@@ -39,6 +44,8 @@ use tuxedo_core::{
     types::Transaction as TuxedoTransaction,
     verifier::{SigCheck, ThresholdMultiSignature, UpForGrabs},
 };
+
+pub use money;
 
 #[cfg(feature = "std")]
 use tuxedo_core::types::OutputRef;

--- a/wardrobe/money/Cargo.toml
+++ b/wardrobe/money/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "money"
+version = "0.1.0"
+edition = "2021"
+description = "A Tuxedo piece that provides a fixed number of simple fingible tokens"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+tuxedo-core = { path = '../../tuxedo-core', default-features = false }
+serde = { version = "1.0", optional = true, features = ["derive"] }
+parity-scale-codec = { version = '3.4.0', default-features = false, features = ['derive'] }
+scale-info = { version = "2.1.1", default-features = false, features = ["derive"] }
+sp-runtime = { git = 'https://github.com/paritytech/substrate', tag = "monthly-2023-05", default_features = false}
+sp-std = { git = 'https://github.com/paritytech/substrate', tag = "monthly-2023-05", default_features = false}
+
+[features]
+default = ["std"]
+std = [
+    "tuxedo-core/std",
+    "parity-scale-codec/std",
+    "sp-runtime/std",
+    "sp-std/std",
+    "serde",
+]

--- a/wardrobe/money/src/lib.rs
+++ b/wardrobe/money/src/lib.rs
@@ -1,5 +1,7 @@
 //! An implementation of a simple fungible token.
 
+#![cfg_attr(not(feature = "std"), no_std)]
+
 use parity_scale_codec::{Decode, Encode};
 use scale_info::TypeInfo;
 #[cfg(feature = "std")]


### PR DESCRIPTION
This PR introduces better code modularity and reusability by moving the example pieces into their own crates.

This allows downstream developers to more easily depend on our pieces when they want them and remove them from the template when they don't.