### PR TITLE
Extrinsics root must use `StateVersion::V0`

### DIFF
--- a/tuxedo-core/src/executive.rs
+++ b/tuxedo-core/src/executive.rs
@@ -266,7 +266,7 @@ impl<
             .unwrap_or_default();
         let extrinsics_root = <<B as BlockT>::Header as HeaderT>::Hashing::ordered_trie_root(
             extrinsics,
-            StateVersion::V1,
+            StateVersion::V0,
         );
         sp_io::storage::clear(EXTRINSIC_KEY);
         header.set_extrinsics_root(extrinsics_root);
@@ -338,7 +338,7 @@ impl<
             .collect::<Vec<_>>();
         let extrinsics_root = <<B as BlockT>::Header as HeaderT>::Hashing::ordered_trie_root(
             extrinsics,
-            StateVersion::V1,
+            StateVersion::V0,
         );
         assert_eq!(
             *block.header().extrinsics_root(),
@@ -948,7 +948,7 @@ mod tests {
                     state_root,
                     extrinsics_root: BlakeTwo256::ordered_trie_root(
                         vec![extrinsic],
-                        StateVersion::V1,
+                        StateVersion::V0,
                     ),
                     digest: Default::default(),
                 };

--- a/tuxedo-template-runtime/src/lib.rs
+++ b/tuxedo-template-runtime/src/lib.rs
@@ -92,7 +92,6 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,
-    // Tuxedo only supports state version 1. You must always use version 1.
     state_version: 1,
 };
 


### PR DESCRIPTION
This small PR changes the way we calculate extrinsics roots to use state version 0 instead of 1. Previously I was just using `V1` because I figured we should use the newest thing.

However, Substrate's networking code uses `V0` and we need to match it or else blocks with extrinsics will not import correctly on other nodes.

https://github.com/paritytech/polkadot-sdk/blob/945ebbbcf66646be13d5b1d1bc26c8b0d3296d9e/substrate/client/network/sync/src/lib.rs#L2415

I discovered this while working on #100 and decided to extract it to its own specific PR