### PR TITLE
Restore doc for transaction inputs

### DIFF
--- a/tuxedo-core/src/types.rs
+++ b/tuxedo-core/src/types.rs
@@ -37,6 +37,7 @@ pub struct OutputRef {
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 #[derive(Debug, PartialEq, Eq, Clone, TypeInfo)]
 pub struct Transaction<V: TypeInfo, C: TypeInfo> {
+    /// Existing pieces of state to be read and consumed from storage
     pub inputs: Vec<Input>,
     /// Existing state to be read, but not consumed, from storage
     pub peeks: Vec<OutputRef>,


### PR DESCRIPTION
This doc string probably got dropped in a botched merge or something. This just brings it back.