### PR TITLE
End of block inherents

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8300,6 +8300,7 @@ dependencies = [
  "sp-api",
  "sp-core",
  "sp-debug-derive",
+ "sp-inherents",
  "sp-io",
  "sp-runtime",
  "sp-std",

--- a/tuxedo-core/Cargo.toml
+++ b/tuxedo-core/Cargo.toml
@@ -19,6 +19,7 @@ derive-no-bound = { path = "no_bound" }
 sp-api = { default_features = false, workspace = true }
 sp-core = { default_features = false, workspace = true }
 sp-debug-derive = { features = [ "force-debug" ], default_features = false, workspace = true }
+sp-inherents = { default_features = false, workspace = true }
 sp-io = { features = [ "with-tracing" ], default_features = false, workspace = true }
 sp-runtime = { default_features = false, workspace = true }
 sp-std = { default_features = false, workspace = true }
@@ -36,6 +37,7 @@ std = [
 	"sp-std/std",
 	"serde",
 	"sp-api/std",
+	"sp-inherents/std",
 	"sp-io/std",
 	"sp-runtime/std",
 	"parity-util-mem",

--- a/tuxedo-core/src/block_builder.rs
+++ b/tuxedo-core/src/block_builder.rs
@@ -1,0 +1,21 @@
+//! This module  contains the definition of the TuxedoBlockBuilder runtime api.
+//! 
+//! Currently this api is intended to be supplimentary to the standard Substrate BlockBuilder
+//! api, but depending on the direction the standard trait evolves, this Tuxedo-specific trait
+//! may eventually become a complete replacement for the standard block builder trait.
+//! See https://github.com/polkadot-fellows/RFCs/pull/13
+
+use sp_api::{BlockT, decl_runtime_apis};
+use sp_inherents::InherentData;
+
+decl_runtime_apis! {
+    /// A runtime API for Tuxedo chains to coordinate end of block inherents.
+    /// This trait is supplementary to the standard Substrate Block Builder api.
+    pub trait TuxedoBlockBuilder {
+        /// Generate the for the end of the block inherent extrinsics.
+        /// The inherent data will vary from chain to chain.
+		fn closing_inherent_extrinsics(
+			inherent: InherentData,
+		) -> sp_std::vec::Vec<<Block as BlockT>::Extrinsic>;
+    }
+}

--- a/tuxedo-core/src/lib.rs
+++ b/tuxedo-core/src/lib.rs
@@ -8,7 +8,7 @@
 
 pub mod dynamic_typing;
 mod executive;
-
+pub mod block_builder;
 pub mod constraint_checker;
 pub mod support_macros;
 pub mod traits;

--- a/tuxedo-core/src/verifier.rs
+++ b/tuxedo-core/src/verifier.rs
@@ -53,6 +53,26 @@ impl Verifier for UpForGrabs {
     }
 }
 
+
+/// A simple verifier that indicates an output is meant as a reward for the author of the block.
+///
+/// The implementation allows anyone to redeem the UTXO, so in that sense it is the same as
+/// UpForGrabs. However, the use of this struct indicates the semantics that this output is
+/// _intended_ only for the block author. And there is no risk of anyone else claiming these
+/// outputs before the author because the author can jsut drop such transactions.
+/// 
+/// In the future the implementation could change so that the output is never redeemable
+/// except by eviction, but evictions are not yet implemented.
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
+#[derive(Encode, Decode, Debug, PartialEq, Eq, Clone, TypeInfo)]
+pub struct TipForAuthor;
+
+impl Verifier for TipForAuthor {
+    fn verify(&self, _simplified_tx: &[u8], _redeemer: &[u8]) -> bool {
+        true
+    }
+}
+
 /// A Threshold multisignature. Some number of member signatories collectively own inputs
 /// guarded by this verifier. A valid redeemer must supply valid signatures by at least
 /// `threshold` of the signatories. If the threshold is greater than the number of signatories


### PR DESCRIPTION
This is an alternative approach to #105 and explores block rewards in a more utxo-native way. This will build on top of #100 and therefore I won't pursue it too much further until that lands.

The general idea is that block authors will have a chance to insert some additional inherent transactions at the end of the block. And in the case of tips specifically, this inherent will consume all of the Tip outputs from the block and reward the block author with a new UTXO.