### PR TITLE
Remove protobuf installation from rustfmt CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,10 +14,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Install tooling
-        run: |
-          sudo apt-get install -y protobuf-compiler
-          protoc --version
       - name: Run Rustfmt
         run: cargo fmt --all -- --check
 


### PR DESCRIPTION
This small PR remove the installation of protoc when running rust fmt. I believe it is not necessary there. But if I'm wrong CI will tell me :)