### PR TITLE
Update wallet and dockerfile to reflect everything on port 9944

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ RUN useradd -m -u 1000 -U -s /bin/sh -d /node-dev node-dev && \
 
 USER node-dev
 
-EXPOSE 30333 9933 9944 9615
+EXPOSE 30333 9944 9615
 VOLUME ["/chain-data"]
 
 ENTRYPOINT ["/usr/local/bin/node-template"]

--- a/wallet/src/main.rs
+++ b/wallet/src/main.rs
@@ -28,7 +28,7 @@ mod sync;
 use cli::{Cli, Command};
 
 /// The default RPC endpoint for the wallet to connect to
-const DEFAULT_ENDPOINT: &str = "http://localhost:9933";
+const DEFAULT_ENDPOINT: &str = "http://localhost:9944";
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {


### PR DESCRIPTION
There was a change in Substrate at some point so that port 9933 is no longer the default for http. In fact it is no longer used at all. Now both http and ws are on port 9944.