### PR TITLE
Update wallet to work with new RPC responses.

### DIFF
--- a/wallet/src/rpc.rs
+++ b/wallet/src/rpc.rs
@@ -2,8 +2,9 @@
 //! RPC endpoint.
 
 use jsonrpsee::{core::client::ClientT, http_client::HttpClient, rpc_params};
-use runtime::Block;
+use runtime::{Transaction, Block, opaque::Block as OpaqueBlock};
 use sp_core::H256;
+use parity_scale_codec::{Encode, Decode};
 
 /// Typed helper to get the Node's block hash at a particular height
 pub async fn node_get_block_hash(height: u32, client: &HttpClient) -> anyhow::Result<Option<H256>> {
@@ -18,9 +19,19 @@ pub async fn node_get_block(hash: H256, client: &HttpClient) -> anyhow::Result<O
     let s = hex::encode(hash.0);
     let params = rpc_params![s];
 
-    let rpc_response: Option<serde_json::Value> = client.request("chain_getBlock", params).await?;
+    let maybe_rpc_response: Option<serde_json::Value> = client.request("chain_getBlock", params).await?;
+    let rpc_response = maybe_rpc_response.unwrap();
 
-    Ok(rpc_response
-        .and_then(|value| value.get("block").cloned())
-        .and_then(|maybe_block| serde_json::from_value(maybe_block).unwrap_or(None)))
+    let json_opaque_block = rpc_response.get("block").cloned().unwrap();
+    let opaque_block: OpaqueBlock = serde_json::from_value(json_opaque_block).unwrap();
+
+    // I need a structured blcok ,not an opaque one. To achieve that, I'll
+    // scale encode it, then once again decode it.
+    // Feels kind of like a hack, but I honestly don't know what else to do.
+    // I don't see any way to get the bytes out of an OpaqueExtrinsic.
+    let scale_bytes = opaque_block.encode();
+
+    let structured_block = Block::decode(&mut &scale_bytes[..]).unwrap();
+    
+    Ok(Some(structured_block))
 }

--- a/wallet/src/rpc.rs
+++ b/wallet/src/rpc.rs
@@ -2,9 +2,9 @@
 //! RPC endpoint.
 
 use jsonrpsee::{core::client::ClientT, http_client::HttpClient, rpc_params};
-use runtime::{Transaction, Block, opaque::Block as OpaqueBlock};
+use parity_scale_codec::{Decode, Encode};
+use runtime::{opaque::Block as OpaqueBlock, Block, Transaction};
 use sp_core::H256;
-use parity_scale_codec::{Encode, Decode};
 
 /// Typed helper to get the Node's block hash at a particular height
 pub async fn node_get_block_hash(height: u32, client: &HttpClient) -> anyhow::Result<Option<H256>> {
@@ -19,7 +19,8 @@ pub async fn node_get_block(hash: H256, client: &HttpClient) -> anyhow::Result<O
     let s = hex::encode(hash.0);
     let params = rpc_params![s];
 
-    let maybe_rpc_response: Option<serde_json::Value> = client.request("chain_getBlock", params).await?;
+    let maybe_rpc_response: Option<serde_json::Value> =
+        client.request("chain_getBlock", params).await?;
     let rpc_response = maybe_rpc_response.unwrap();
 
     let json_opaque_block = rpc_response.get("block").cloned().unwrap();
@@ -32,6 +33,6 @@ pub async fn node_get_block(hash: H256, client: &HttpClient) -> anyhow::Result<O
     let scale_bytes = opaque_block.encode();
 
     let structured_block = Block::decode(&mut &scale_bytes[..]).unwrap();
-    
+
     Ok(Some(structured_block))
 }

--- a/wallet/src/rpc.rs
+++ b/wallet/src/rpc.rs
@@ -3,7 +3,7 @@
 
 use jsonrpsee::{core::client::ClientT, http_client::HttpClient, rpc_params};
 use parity_scale_codec::{Decode, Encode};
-use runtime::{opaque::Block as OpaqueBlock, Block, Transaction};
+use runtime::{opaque::Block as OpaqueBlock, Block};
 use sp_core::H256;
 
 /// Typed helper to get the Node's block hash at a particular height


### PR DESCRIPTION
Solves #120 (hopefully)

I'm not sure exactly when or why something changed in jsonrpsee or some other dependency and the wallet could no longer decode structured blocks from the RPC's json response.

This PR works around the issue by having the wallet first decode the json into an opaque block, and then get a structured block by making a round trip encode/decode to scale bytes.

I'm not sure if there is a more efficient or elegant way to get a structured block on the wallet side, but this is the only thing I could figure out to make the wallet work again.