### PR TITLE
make CI delete old comments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
         - if: github.event_name == 'pull_request' &&
               github.event.pull_request.head.repo.full_name == github.repository
           name: Report code coverage
-          uses: Nef10/lcov-reporter-action@v0.4.0
+          uses: romeovs/lcov-reporter-action@master
           with:
             lcov-file: lcov.info
             pr-number: ${{ github.event.pull_request.number }}

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ Tuxedo strives for excellent code quality which is enforced through unit tests, 
 # Run unit tests on all aspects of the project
 cargo test
 
-# Run clippy (which requires nightly)
+# Run clippy with nightly
 cargo +nightly clippy
 ```
 


### PR DESCRIPTION
While reviewing #100 I noticed that aforesaid feature silently introduced in #113 does not work.
I hope switching to this other fork of the action will fix it, without introducing other problems.