### PR TITLE
improve CI tests

### DIFF
--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -6,10 +6,14 @@ branding:
   color: "green"
 
 inputs:
-  args:
-    description: "Arguments to pass to `cargo nextest run`."
+  packages:
+    description: "Packages to be tested by `cargo nextest`."
     required: true
     default: ""
+  ignore:
+    description: "Folders or files to be ignored by `cargo llvm-cov report`."
+    required: true
+    default: "target" # we need a default value, otherwise the command doesn't work
   title:
     description: "Title of the comment with the code coverage."
     required: true
@@ -33,17 +37,21 @@ runs:
         cache-on-failure: true
     - name: Run tests and print coverage data
       shell: bash
-      run: cargo llvm-cov nextest
-        ${{ inputs.args }}
-        --json --output-path lcov.json --summary-only &&
-        echo "Lines coverage " && jq ".data[0].totals.lines.percent" lcov.json
+      run: |
+        pkgs=`for p in ${{ inputs.packages }}; do echo -n "-p $p "; done`;
+        cargo llvm-cov nextest $pkgs --json --summary-only --output-path lcov.json &&
+        perc=`jq ".data[0].totals.lines.percent" lcov.json` &&
+        echo Lines coverage: ${perc:0:5}%
     # if the PR is on the same repo, the coverage data can be reported as a comment
     - if: github.event_name == 'pull_request' &&
         github.event.pull_request.head.repo.full_name == github.repository
       name: Generate lcov report
       shell: bash
-      run: cargo llvm-cov report --lcov --output-path lcov.info
-        --ignore-filename-regex "node/"
+      run: |
+        function join_by { local IFS="$1"; shift; echo "$*"; };
+        ignore=`join_by \| ${{ inputs.ignore }}`;
+        cargo llvm-cov report --lcov --output-path lcov.info \
+        --ignore-filename-regex "$ignore"
     - if: github.event_name == 'pull_request' &&
         github.event.pull_request.head.repo.full_name == github.repository
       name: Report code coverage

--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -23,9 +23,7 @@ runs:
   steps:
     - name: Install tooling
       shell: bash
-      run: |
-        sudo apt-get install -y protobuf-compiler
-        protoc --version
+      run: sudo apt-get install -y protobuf-compiler && protoc --version
     - name: Install latest nextest release
       uses: taiki-e/install-action@nextest
     - name: Install cargo-llvm-cov

--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -37,7 +37,8 @@ runs:
       shell: bash
       run: |
         pkgs=`for p in ${{ inputs.packages }}; do echo -n "-p $p "; done`;
-        cargo llvm-cov nextest $pkgs --json --summary-only --output-path lcov.json &&
+        cargo llvm-cov nextest --release \
+        $pkgs --json --summary-only --output-path lcov.json &&
         perc=`jq ".data[0].totals.lines.percent" lcov.json` &&
         echo Lines coverage: ${perc:0:5}%
     # if the PR is on the same repo, the coverage data can be reported as a comment

--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -50,6 +50,5 @@ runs:
       uses: romeovs/lcov-reporter-action@master
       with:
         lcov-file: lcov.info
-        pr-number: ${{ github.event.pull_request.number }}
         delete-old-comments: true
         title: ${{ inputs.title }}

--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -1,0 +1,55 @@
+name: "Test and code coverage"
+description: "Run tests with nextest and report code coverage in a PR comment."
+author: "Off-Narrative Labs"
+branding:
+  icon: "check-circle"
+  color: "green"
+
+inputs:
+  args:
+    description: "Arguments to pass to `cargo nextest run`."
+    required: true
+    default: ""
+  title:
+    description: "Title of the comment with the code coverage."
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: Install tooling
+      shell: bash
+      run: |
+        sudo apt-get install -y protobuf-compiler
+        protoc --version
+    - name: Install latest nextest release
+      uses: taiki-e/install-action@nextest
+    - name: Install cargo-llvm-cov
+      uses: taiki-e/install-action@cargo-llvm-cov
+    - name: Rust Cache
+      uses: Swatinem/rust-cache@v2
+      with:
+        cache-targets: true
+        cache-on-failure: true
+    - name: Run tests and print coverage data
+      shell: bash
+      run: cargo llvm-cov nextest
+        ${{ inputs.args }}
+        --json --output-path lcov.json --summary-only &&
+        echo "Lines coverage " && jq ".data[0].totals.lines.percent" lcov.json
+    # if the PR is on the same repo, the coverage data can be reported as a comment
+    - if: github.event_name == 'pull_request' &&
+        github.event.pull_request.head.repo.full_name == github.repository
+      name: Generate lcov report
+      shell: bash
+      run: cargo llvm-cov report --lcov --output-path lcov.info
+        --ignore-filename-regex "node/"
+    - if: github.event_name == 'pull_request' &&
+        github.event.pull_request.head.repo.full_name == github.repository
+      name: Report code coverage
+      uses: romeovs/lcov-reporter-action@master
+      with:
+        lcov-file: lcov.info
+        pr-number: ${{ github.event.pull_request.number }}
+        delete-old-comments: true
+        title: ${{ inputs.title }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,16 +84,13 @@ jobs:
           title: "Code Coverage for Tuxedo Wardrobe Pieces"
 
   clippy:
-    if: false
     name: Clippy
     needs: [fmt, toml-sort]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: Install tooling
-        run: |
-          sudo apt-get install -y protobuf-compiler
-          protoc --version
+        run: sudo apt-get install -y protobuf-compiler && protoc --version
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2
         with:
@@ -103,16 +100,13 @@ jobs:
         run: cargo clippy --no-deps -- -D warnings
 
   wallet:
-    if: false
     name: Wallet end-to-end test
     needs: [fmt, toml-sort]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: Install tooling
-        run: |
-          sudo apt-get install -y protobuf-compiler
-          protoc --version
+        run: sudo apt-get install -y protobuf-compiler && protoc --version
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,8 +27,8 @@ jobs:
           all: true
           match: "Cargo.toml"
 
-  test:
-    name: Test and code coverage
+  test-core:
+    name: Test and Code Coverage for `tuxedo-core`
     needs: [fmt, toml-sort]
     runs-on: ubuntu-latest
     permissions:
@@ -36,39 +36,24 @@ jobs:
       pull-requests: write
     steps:
       - uses: actions/checkout@v4
-      - name: Install tooling
-        run: |
-          sudo apt-get install -y protobuf-compiler
-          protoc --version
-      - name: Install latest nextest release
-        uses: taiki-e/install-action@nextest
-      - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@cargo-llvm-cov
-      - name: Rust Cache
-        uses: Swatinem/rust-cache@v2
+      - uses: ./.github/actions/test
         with:
-          cache-targets: true
-          cache-on-failure: true
-      - name: Run tests and print coverage data
-        run: cargo llvm-cov nextest --workspace
-          --exclude node-template --exclude parachain-template-node
-          --exclude derive-no-bound
-          --json --output-path lcov.json --summary-only &&
-          echo "Lines coverage " && jq ".data[0].totals.lines.percent" lcov.json
-      # if the PR is on the same repo, the coverage data can be reported as a comment
-      - if: github.event_name == 'pull_request' &&
-          github.event.pull_request.head.repo.full_name == github.repository
-        name: Generate lcov report
-        run: cargo llvm-cov report --lcov --output-path lcov.info
-          --ignore-filename-regex "node/"
-      - if: github.event_name == 'pull_request' &&
-          github.event.pull_request.head.repo.full_name == github.repository
-        name: Report code coverage
-        uses: romeovs/lcov-reporter-action@master
+          args: -p tuxedo-core
+          title: "Code Coverage for `tuxedo-core`"
+
+  test-parachain:
+    name: Test and Code Coverage for `tuxedo-parachain-core`
+    needs: [fmt, toml-sort]
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/test
         with:
-          lcov-file: lcov.info
-          pr-number: ${{ github.event.pull_request.number }}
-          delete-old-comments: true
+          args: -p tuxedo-parachain-core
+          title: "Code Coverage for `tuxedo-parachain-core`"
 
   clippy:
     name: Clippy

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
           match: "Cargo.toml"
 
   test-core:
-    name: Test and Code Coverage for `tuxedo-core`
+    name: Test and Code Coverage for Tuxedo Core
     needs: [fmt, toml-sort]
     runs-on: ubuntu-latest
     permissions:
@@ -38,11 +38,11 @@ jobs:
       - uses: ./.github/actions/test
         with:
           packages: tuxedo-core
-          title: "Code Coverage for `tuxedo-core`"
+          title: "Code Coverage for Tuxedo Core"
 
   test-parachain:
     if: false # we skip this for now because of not enough space
-    name: Test and Code Coverage for `tuxedo-parachain-core`
+    name: Test and Code Coverage for Tuxedo Parachain Core and Piece
     needs: [fmt, toml-sort]
     runs-on: ubuntu-latest
     permissions:
@@ -51,12 +51,12 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/test
         with:
-          packages: tuxedo-parachain-core
+          packages: tuxedo-parachain-core parachain-piece
           ignore: tuxedo-core
-          title: "Code Coverage for `tuxedo-parachain-core`"
+          title: "Code Coverage for Tuxedo Parachain Core and Piece"
 
   test-runtime:
-    name: Test and Code Coverage for `tuxedo-template-runtime`
+    name: Test and Code Coverage for Tuxedo Template Runtime
     needs: [fmt, toml-sort]
     runs-on: ubuntu-latest
     permissions:
@@ -67,10 +67,10 @@ jobs:
         with:
           packages: tuxedo-template-runtime
           ignore: tuxedo-core wardrobe
-          title: "Code Coverage for `tuxedo-template-runtime`"
+          title: "Code Coverage for Tuxedo Template Runtime"
 
   test-wardrobe:
-    name: Test and Code Coverage for Tuxedo Wardrobe
+    name: Test and Code Coverage for Tuxedo Wardrobe Pieces
     needs: [fmt, toml-sort]
     runs-on: ubuntu-latest
     permissions:
@@ -79,9 +79,9 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/test
         with:
-          packages: kitties money parachain-piece poe runtime-upgrade timestamp
-          ignore: tuxedo-core tuxedo-parachain-core
-          title: "Code Coverage for Tuxedo Wardrobe"
+          packages: kitties money poe runtime-upgrade timestamp
+          ignore: tuxedo-core
+          title: "Code Coverage for Tuxedo Wardrobe Pieces"
 
   clippy:
     if: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,6 @@ jobs:
           title: "Code Coverage for Tuxedo Core"
 
   test-parachain:
-    if: false # we skip this for now because of not enough space
     name: Test and Code Coverage for Tuxedo Parachain Core and Piece
     needs: [fmt, toml-sort]
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,6 @@ jobs:
     needs: [fmt, toml-sort]
     runs-on: ubuntu-latest
     permissions:
-      issues: write
       pull-requests: write
     steps:
       - uses: actions/checkout@v4
@@ -46,7 +45,6 @@ jobs:
     needs: [fmt, toml-sort]
     runs-on: ubuntu-latest
     permissions:
-      issues: write
       pull-requests: write
     steps:
       - uses: actions/checkout@v4
@@ -54,6 +52,35 @@ jobs:
         with:
           args: -p tuxedo-parachain-core
           title: "Code Coverage for `tuxedo-parachain-core`"
+
+  test-runtime:
+    name: Test and Code Coverage for `tuxedo-template-runtime`
+    needs: [fmt, toml-sort]
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/test
+        with:
+          args: -p tuxedo-template-runtime
+          title: "Code Coverage for `tuxedo-template-runtime`"
+
+  test-wardrobe:
+    name: Test and Code Coverage for Tuxedo Wardrobe
+    needs: [fmt, toml-sort]
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/test
+        with:
+          args: \
+            -p amoeba -p kitties -p money \
+            -p parachain-piece -p poe \
+            -p runtime-upgrade -p timestamp
+          title: "Code Coverage for Tuxedo Wardrobe"
 
   clippy:
     name: Clippy

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,10 +37,11 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/test
         with:
-          args: -p tuxedo-core
+          packages: tuxedo-core
           title: "Code Coverage for `tuxedo-core`"
 
   test-parachain:
+    if: false # we skip this for now because of not enough space
     name: Test and Code Coverage for `tuxedo-parachain-core`
     needs: [fmt, toml-sort]
     runs-on: ubuntu-latest
@@ -50,7 +51,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/test
         with:
-          args: -p tuxedo-parachain-core
+          packages: tuxedo-parachain-core
+          ignore: tuxedo-core
           title: "Code Coverage for `tuxedo-parachain-core`"
 
   test-runtime:
@@ -63,7 +65,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/test
         with:
-          args: -p tuxedo-template-runtime
+          packages: tuxedo-template-runtime
+          ignore: tuxedo-core wardrobe
           title: "Code Coverage for `tuxedo-template-runtime`"
 
   test-wardrobe:
@@ -76,13 +79,12 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/test
         with:
-          args: \
-            -p amoeba -p kitties -p money \
-            -p parachain-piece -p poe \
-            -p runtime-upgrade -p timestamp
+          packages: kitties money parachain-piece poe runtime-upgrade timestamp
+          ignore: tuxedo-core tuxedo-parachain-core
           title: "Code Coverage for Tuxedo Wardrobe"
 
   clippy:
+    if: false
     name: Clippy
     needs: [fmt, toml-sort]
     runs-on: ubuntu-latest
@@ -101,6 +103,7 @@ jobs:
         run: cargo clippy --no-deps -- -D warnings
 
   wallet:
+    if: false
     name: Wallet end-to-end test
     needs: [fmt, toml-sort]
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR introduces a custom action to run tests for different crates, and updates the workflow to use this action for testing:
- `tuxedo-core`;
- `tuxedo-parachain-core` and `parachain-piece`, which is currently skipped as it fails because it uses too much disk space;
- `tuxedo-template-runtime`, which I think we could skip entirely;
- all the other wardrobe pieces, which should be updated manually when the list changes.

This PR is a step towards #155.