### PR TITLE
Add maximize-build-space action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,8 @@ jobs:
       issues: write
       pull-requests: write
     steps:
+      # Polkadot crates are so bloaty, we need this hacky action to claim more disk space.
+      - uses: easimon/maximize-build-space@v10
       - uses: actions/checkout@v4
       - name: Install tooling
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
           cache-targets: true
           cache-on-failure: true
       - name: Run tests and print coverage data
-        run: cargo llvm-cov nextest --workspace
+        run: cargo llvm-cov nextest --release --workspace
           --exclude node-template --exclude parachain-template-node
           --exclude derive-no-bound
           --json --output-path lcov.json --summary-only &&


### PR DESCRIPTION
inspired by cdaa8c7bb385ca42359d0071348b2a7805dc55d3

This PR adds this simple magical (hacky) github action which gets us enough extra disk space to build the massive polkadot crates.