### PR TITLE
Wallet: mint-coins functionality

### DIFF
--- a/wallet/README.md
+++ b/wallet/README.md
@@ -133,25 +133,6 @@ Both sources agree that the coin exists, is worth 100, and is owned by Shawn.
 
 Let's "split" this coin by creating a transaction that spends it and creates two new coins worth 40 and 50, burning the remaining 10.
 
-### Minting coins
-It is possible to mint new coins with the wallet.
-We can optionally pass the amount and public key of the owner as arguments to mint_coins.
-If optional arguments are not passed below are the default values:
-the amount is 100 coin
-owner(public key) is 0xd2bf4b844dfefd6772a8843e669f943408966a977e3ae2af1dd78e0f55f4df67 i.e SHAWN_PUB_KEY
-
-```sh
-$ tuxedo-template-wallet mint-coins \
- --owner 0xdeba7f5d5088cda3e32ccaf479056dd934d87fa8129987ca6db57c122bd73341 \
- --amount 200 \
-
-[2024-01-18T14:22:19Z INFO  tuxedo_template_wallet] Number of blocks in the db: 6
-[2024-01-18T14:22:19Z INFO  tuxedo_template_wallet] Wallet database synchronized with node to height 14
-[2024-01-18T14:22:19Z INFO  tuxedo_template_wallet::money] Node's response to mint-coin transaction: Ok("0xaff830b7755fee67c288afe18dfa6eabffe06286005b0fd6cb8e57b246c08df6")
-Created "f76373909591d85f796c36ed4b265e46efabdf5b5c493b94246d590823cc42a500000000" worth 200. owned by 0xdeba…3341
-```
-It is possible to verify a newly minted coin exists in both chain storage and the local database using verify-coin command.
-
 ```sh
 $ tuxedo-template-wallet spend-coins \
   --output-amount 40 \
@@ -184,6 +165,26 @@ total      : 90
 ```
 
 In this case we didn't specify a recipient of the new outputs, so the same default address was used. Next let's explore using some other keys.
+
+### Minting coins
+
+It is possible to mint new coins with the wallet.
+We can optionally pass the amount and public key of the owner as arguments to mint_coins.
+If optional arguments are not passed below are the default values:
+the amount is 100 coin
+owner(public key) is 0xd2bf4b844dfefd6772a8843e669f943408966a977e3ae2af1dd78e0f55f4df67 i.e SHAWN_PUB_KEY
+
+```sh
+$ tuxedo-template-wallet mint-coins \
+ --owner 0xdeba7f5d5088cda3e32ccaf479056dd934d87fa8129987ca6db57c122bd73341 \
+ --amount 200 \
+
+[2024-01-18T14:22:19Z INFO  tuxedo_template_wallet] Number of blocks in the db: 6
+[2024-01-18T14:22:19Z INFO  tuxedo_template_wallet] Wallet database synchronized with node to height 14
+[2024-01-18T14:22:19Z INFO  tuxedo_template_wallet::money] Node's response to mint-coin transaction: Ok("0xaff830b7755fee67c288afe18dfa6eabffe06286005b0fd6cb8e57b246c08df6")
+Created "f76373909591d85f796c36ed4b265e46efabdf5b5c493b94246d590823cc42a500000000" worth 200. owned by 0xdeba…3341
+```
+It is possible to verify a newly minted coin exists in both chain storage and the local database using verify-coin command.
 
 ### Using Your Own Keys
 

--- a/wallet/README.md
+++ b/wallet/README.md
@@ -142,16 +142,15 @@ owner(public key) is 0xd2bf4b844dfefd6772a8843e669f943408966a977e3ae2af1dd78e0f5
 
 ```sh
 $ tuxedo-template-wallet mint-coins \
- --owner f41a866782d45a4d2d8a623a097c62aee6955a9e580985e3910ba49eded9e06b \
- --amount 700 \
+ --owner 0xdeba7f5d5088cda3e32ccaf479056dd934d87fa8129987ca6db57c122bd73341 \
+ --amount 200 \
 
-[2024-01-16T07:23:31Z INFO  tuxedo_template_wallet] Number of blocks in the db: 66
-[2024-01-16T07:23:32Z INFO  tuxedo_template_wallet] Wallet database synchronized with node to height 260
-Minted coin from storage = (Coin(700), Sr25519Signature(Sr25519Signature { owner_pubkey: 0xd2bf4b844dfefd6772a8843e669f943408966a977e3ae2af1dd78e0f55f4df67 }))
-
-Now check all the coins available in the wallet, newly minted coins must also exist by the below cmd.
-$ tuxedo-template-wallet show-all-outputs
+[2024-01-18T14:22:19Z INFO  tuxedo_template_wallet] Number of blocks in the db: 6
+[2024-01-18T14:22:19Z INFO  tuxedo_template_wallet] Wallet database synchronized with node to height 14
+[2024-01-18T14:22:19Z INFO  tuxedo_template_wallet::money] Node's response to mint-coin transaction: Ok("0xaff830b7755fee67c288afe18dfa6eabffe06286005b0fd6cb8e57b246c08df6")
+Created "f76373909591d85f796c36ed4b265e46efabdf5b5c493b94246d590823cc42a500000000" worth 200. owned by 0xdeba…3341
 ```
+It is possible to verify a newly minted coin exists in both chain storage and the local database using verify-coin command.
 
 ```sh
 $ tuxedo-template-wallet spend-coins \

--- a/wallet/README.md
+++ b/wallet/README.md
@@ -139,7 +139,6 @@ We can optionally pass the amount and public key of the owner as arguments to mi
 If optional arguments are not passed below are the default values:
 the amount is 100 coin
 owner(public key) is 0xd2bf4b844dfefd6772a8843e669f943408966a977e3ae2af1dd78e0f55f4df67 i.e SHAWN_PUB_KEY
-The max limit for coin value is 1000. If the amount >1000 then the minting amount will be floored to 1000.
 
 ```sh
 $ tuxedo-template-wallet mint-coins \

--- a/wallet/README.md
+++ b/wallet/README.md
@@ -166,26 +166,6 @@ total      : 90
 
 In this case we didn't specify a recipient of the new outputs, so the same default address was used. Next let's explore using some other keys.
 
-### Minting coins
-
-It is possible to mint new coins with the wallet.
-We can optionally pass the amount and public key of the owner as arguments to mint_coins.
-If optional arguments are not passed below are the default values:
-the amount is 100 coin
-owner(public key) is 0xd2bf4b844dfefd6772a8843e669f943408966a977e3ae2af1dd78e0f55f4df67 i.e SHAWN_PUB_KEY
-
-```sh
-$ tuxedo-template-wallet mint-coins \
- --owner 0xdeba7f5d5088cda3e32ccaf479056dd934d87fa8129987ca6db57c122bd73341 \
- --amount 200 \
-
-[2024-01-18T14:22:19Z INFO  tuxedo_template_wallet] Number of blocks in the db: 6
-[2024-01-18T14:22:19Z INFO  tuxedo_template_wallet] Wallet database synchronized with node to height 14
-[2024-01-18T14:22:19Z INFO  tuxedo_template_wallet::money] Node's response to mint-coin transaction: Ok("0xaff830b7755fee67c288afe18dfa6eabffe06286005b0fd6cb8e57b246c08df6")
-Created "f76373909591d85f796c36ed4b265e46efabdf5b5c493b94246d590823cc42a500000000" worth 200. owned by 0xdeba…3341
-```
-It is possible to verify a newly minted coin exists in both chain storage and the local database using verify-coin command.
-
 ### Using Your Own Keys
 
 Of course we can use other keys than the example Shawn key.
@@ -237,6 +217,27 @@ Balance Summary
 --------------------
 total      : 80
 ```
+
+It is possible to create new coins using the wallet. Let's explore how to do it.
+
+### Minting coins
+
+We can optionally pass the amount and public key of the owner as arguments to mint_coins.
+If optional arguments are not passed below are the default values:
+Amount is `100` and Public key of owner is Shawn key.
+
+```sh
+$ tuxedo-template-wallet mint-coins \
+ --owner 0xdeba7f5d5088cda3e32ccaf479056dd934d87fa8129987ca6db57c122bd73341 \
+ --amount 200 \
+
+[2024-01-18T14:22:19Z INFO  tuxedo_template_wallet] Number of blocks in the db: 6
+[2024-01-18T14:22:19Z INFO  tuxedo_template_wallet] Wallet database synchronized with node to height 14
+[2024-01-18T14:22:19Z INFO  tuxedo_template_wallet::money] Node's response to mint-coin transaction: Ok("0xaff830b7755fee67c288afe18dfa6eabffe06286005b0fd6cb8e57b246c08df6")
+Created "f76373909591d85f796c36ed4b265e46efabdf5b5c493b94246d590823cc42a500000000" worth 200. owned by 0xdeba…3341
+```
+It is possible to verify a newly minted coin exists in both chain storage and the local database using verify-coin command.
+
 
 ### Manually Selecting Inputs
 

--- a/wallet/README.md
+++ b/wallet/README.md
@@ -134,7 +134,7 @@ Both sources agree that the coin exists, is worth 100, and is owned by Shawn.
 Let's "split" this coin by creating a transaction that spends it and creates two new coins worth 40 and 50, burning the remaining 10.
 
 ### Minting coins
-It is possible to mint the coins via wallet.
+It is possible to mint new coins with the wallet.
 We can optionally pass the amount and public key of the owner as arguments to mint_coins.
 If optional arguments are not passed below are the default values:
 the amount is 100 coin
@@ -149,7 +149,9 @@ $ tuxedo-template-wallet mint-coins \
 [2024-01-16T07:23:32Z INFO  tuxedo_template_wallet] Wallet database synchronized with node to height 260
 Minted coin from storage = (Coin(700), Sr25519Signature(Sr25519Signature { owner_pubkey: 0xd2bf4b844dfefd6772a8843e669f943408966a977e3ae2af1dd78e0f55f4df67 }))
 
-Now check all the coins available in the wallet, newly minted coins must exist by the below cmd.
+Now check all the coins available in the wallet, newly minted coins must also exist by the below cmd.
+$ tuxedo-template-wallet show-all-outputs
+```
 
 ```sh
 $ tuxedo-template-wallet spend-coins \

--- a/wallet/README.md
+++ b/wallet/README.md
@@ -133,6 +133,25 @@ Both sources agree that the coin exists, is worth 100, and is owned by Shawn.
 
 Let's "split" this coin by creating a transaction that spends it and creates two new coins worth 40 and 50, burning the remaining 10.
 
+### Minting coins
+It is possible to mint the coins via wallet.
+We can optionally pass the amount and public key of the owner as arguments to mint_coins.
+If optional arguments are not passed below are the default values:
+the amount is 100 coin
+owner(public key) is 0xd2bf4b844dfefd6772a8843e669f943408966a977e3ae2af1dd78e0f55f4df67 i.e SHAWN_PUB_KEY
+The max limit for coin value is 1000. If the amount >1000 then the minting amount will be floored to 1000.
+
+```sh
+$ tuxedo-template-wallet mint-coins \
+ --owner f41a866782d45a4d2d8a623a097c62aee6955a9e580985e3910ba49eded9e06b \
+ --amount 700 \
+
+[2024-01-16T07:23:31Z INFO  tuxedo_template_wallet] Number of blocks in the db: 66
+[2024-01-16T07:23:32Z INFO  tuxedo_template_wallet] Wallet database synchronized with node to height 260
+Minted coin from storage = (Coin(700), Sr25519Signature(Sr25519Signature { owner_pubkey: 0xd2bf4b844dfefd6772a8843e669f943408966a977e3ae2af1dd78e0f55f4df67 }))
+
+Now check all the coins available in the wallet, newly minted coins must exist by the below cmd.
+
 ```sh
 $ tuxedo-template-wallet spend-coins \
   --output-amount 40 \

--- a/wallet/src/cli.rs
+++ b/wallet/src/cli.rs
@@ -10,7 +10,9 @@ use tuxedo_core::types::OutputRef;
 
 use crate::{h256_from_string, keystore::SHAWN_PUB_KEY, output_ref_from_string, DEFAULT_ENDPOINT};
 
-use crate::money::DEFAULT_NUM_OF_COINS;
+/// The default number of coins to be minted.
+pub const DEFAULT_MINT_VALUE: &str = "100";
+
 /// The wallet's main CLI struct
 #[derive(Debug, Parser)]
 #[command(about, version)]
@@ -113,7 +115,7 @@ pub enum Command {
 #[derive(Debug, Args)]
 pub struct MintCoinArgs {
     /// Pass the amount to be minted.
-    #[arg(long, short, verbatim_doc_comment, action = Append,default_value = DEFAULT_NUM_OF_COINS)]
+    #[arg(long, short, verbatim_doc_comment, action = Append,default_value = DEFAULT_MINT_VALUE)]
     pub amount: u128,
 
     // https://docs.rs/clap/latest/clap/_derive/_cookbook/typed_derive/index.html

--- a/wallet/src/cli.rs
+++ b/wallet/src/cli.rs
@@ -10,6 +10,7 @@ use tuxedo_core::types::OutputRef;
 
 use crate::{h256_from_string, keystore::SHAWN_PUB_KEY, output_ref_from_string, DEFAULT_ENDPOINT};
 
+use crate::{money::DEFAULT_NUM_OF_COINS};
 /// The wallet's main CLI struct
 #[derive(Debug, Parser)]
 #[command(about, version)]
@@ -112,13 +113,13 @@ pub enum Command {
 #[derive(Debug, Args)]
 pub struct MintCoinArgs {
 
-    /// Pass the amount to be minted, if not passed 100 coins will be minted 
-    #[arg(long, short, verbatim_doc_comment, action = Append)]
-    pub amount: Option<u128>,
+    /// Pass the amount to be minted.
+    #[arg(long, short, verbatim_doc_comment, action = Append,default_value = DEFAULT_NUM_OF_COINS)]
+    pub amount: u128,
 
     // https://docs.rs/clap/latest/clap/_derive/_cookbook/typed_derive/index.html
     // shows how to specify a custom parsing function
-    /// Hex encoded address (sr25519 pubkey) of the owner, if not passed ,by defauly SHAWN_PUB_KEY is used.
+    /// Hex encoded address (sr25519 pubkey) of the owner.
     #[arg(long, short, verbatim_doc_comment, value_parser = h256_from_string, default_value = SHAWN_PUB_KEY)]
     pub owner: H256,
 }

--- a/wallet/src/cli.rs
+++ b/wallet/src/cli.rs
@@ -10,7 +10,7 @@ use tuxedo_core::types::OutputRef;
 
 use crate::{h256_from_string, keystore::SHAWN_PUB_KEY, output_ref_from_string, DEFAULT_ENDPOINT};
 
-use crate::{money::DEFAULT_NUM_OF_COINS};
+use crate::money::DEFAULT_NUM_OF_COINS;
 /// The wallet's main CLI struct
 #[derive(Debug, Parser)]
 #[command(about, version)]
@@ -48,8 +48,8 @@ pub enum Command {
     /// Demonstrate creating an amoeba and performing mitosis on it.
     AmoebaDemo,
 
-    /// Mint coins , optionally amount and publicKey of owner can be passed 
-    /// if amount is not passed , 100 coins are minted 
+    /// Mint coins , optionally amount and publicKey of owner can be passed
+    /// if amount is not passed , 100 coins are minted
     /// If publickKey of owner is not passed , then by default SHAWN_PUB_KEY is used.
     #[command(verbatim_doc_comment)]
     MintCoins(MintCoinArgs),
@@ -112,7 +112,6 @@ pub enum Command {
 
 #[derive(Debug, Args)]
 pub struct MintCoinArgs {
-
     /// Pass the amount to be minted.
     #[arg(long, short, verbatim_doc_comment, action = Append,default_value = DEFAULT_NUM_OF_COINS)]
     pub amount: u128,

--- a/wallet/src/cli.rs
+++ b/wallet/src/cli.rs
@@ -47,6 +47,12 @@ pub enum Command {
     /// Demonstrate creating an amoeba and performing mitosis on it.
     AmoebaDemo,
 
+    /// Mint coins , optionally amount and publicKey of owner can be passed 
+    /// if amount is not passed , 100 coins are minted 
+    /// If publickKey of owner is not passed , then by default SHAWN_PUB_KEY is used.
+    #[command(verbatim_doc_comment)]
+    MintCoins(MintCoinArgs),
+
     /// Verify that a particular coin exists.
     /// Show its value and owner from both chain storage and the local database.
     #[command(verbatim_doc_comment)]
@@ -101,6 +107,20 @@ pub enum Command {
 
     /// Show the latest on-chain timestamp.
     ShowTimestamp,
+}
+
+#[derive(Debug, Args)]
+pub struct MintCoinArgs {
+
+    /// Pass the amount to be minted, if not passed 100 coins will be minted 
+    #[arg(long, short, verbatim_doc_comment, action = Append)]
+    pub amount: Option<u128>,
+
+    // https://docs.rs/clap/latest/clap/_derive/_cookbook/typed_derive/index.html
+    // shows how to specify a custom parsing function
+    /// Hex encoded address (sr25519 pubkey) of the owner, if not passed ,by defauly SHAWN_PUB_KEY is used.
+    #[arg(long, short, verbatim_doc_comment, value_parser = h256_from_string, default_value = SHAWN_PUB_KEY)]
+    pub owner: H256,
 }
 
 #[derive(Debug, Args)]

--- a/wallet/src/main.rs
+++ b/wallet/src/main.rs
@@ -99,6 +99,7 @@ async fn main() -> anyhow::Result<()> {
     match cli.command {
         Some(Command::AmoebaDemo) => amoeba::amoeba_demo(&client).await,
         // Command::MultiSigDemo => multi_sig::multi_sig_demo(&client).await,
+        Some(Command::MintCoins(args)) => money::mint_coins(&client, args).await,
         Some(Command::VerifyCoin { output_ref }) => {
             println!("Details of coin {}:", hex::encode(output_ref.encode()));
 

--- a/wallet/src/money.rs
+++ b/wallet/src/money.rs
@@ -21,34 +21,20 @@ use tuxedo_core::{
 use std::{thread::sleep, time::Duration};
 
 /// The default number of coins to be minted.
-const DEFAULT_NUM_OF_COINS: u128 = 100;
-
-/// The Max value of coins can be minted.
-const MAX_NUM_OF_COINS: u128 = 1000;
+pub const DEFAULT_NUM_OF_COINS: &str = "100";
 
 /// Create and send a transaction that mints the coins on the network
 pub async fn mint_coins(
     client: &HttpClient,
     args: MintCoinArgs,
 ) -> anyhow::Result<()> {
-    log::debug!("The args are:: {:?}", args);
-    let amount = match args.amount {
-        Some(mut amt) => {
-            if amt > MAX_NUM_OF_COINS {
-                amt = MAX_NUM_OF_COINS; // if the amount is >1k 
-            }
-            amt
-        },
-        None => DEFAULT_NUM_OF_COINS,// 100 coin is default amount.
-    };
-
-    let owner = args.owner;
+    log::info!("The args are:: {:?}", args);
 
     let transaction = Transaction {
         inputs: Vec::new(),
         peeks: Vec::new(),
-        outputs: vec![(Coin::<0>::new(amount), OuterVerifier::Sr25519Signature(Sr25519Signature {
-            owner_pubkey: owner,
+        outputs: vec![(Coin::<0>::new(args.amount), OuterVerifier::Sr25519Signature(Sr25519Signature {
+            owner_pubkey: args.owner,
         })).into()],
         checker: OuterConstraintChecker::Money(MoneyConstraintChecker::Mint),
     };

--- a/wallet/src/money.rs
+++ b/wallet/src/money.rs
@@ -1,6 +1,6 @@
 //! Wallet features related to spending money and checking balances.
 
-use crate::{cli::SpendArgs, rpc::fetch_storage, sync};
+use crate::{cli::MintCoinArgs, cli::SpendArgs, rpc::fetch_storage, sync};
 
 use anyhow::anyhow;
 use jsonrpsee::{core::client::ClientT, http_client::HttpClient, rpc_params};
@@ -17,6 +17,57 @@ use tuxedo_core::{
     types::{Input, Output, OutputRef},
     verifier::Sr25519Signature,
 };
+
+use std::{thread::sleep, time::Duration};
+
+/// The default number of coins to be minted.
+const DEFAULT_NUM_OF_COINS: u128 = 100;
+
+/// The Max value of coins can be minted.
+const MAX_NUM_OF_COINS: u128 = 1000;
+
+/// Create and send a transaction that mints the coins on the network
+pub async fn mint_coins(
+    client: &HttpClient,
+    args: MintCoinArgs,
+) -> anyhow::Result<()> {
+    log::debug!("The args are:: {:?}", args);
+    let amount = match args.amount {
+        Some(mut amt) => {
+            if amt > MAX_NUM_OF_COINS {
+                amt = MAX_NUM_OF_COINS; // if the amount is >1k 
+            }
+            amt
+        },
+        None => DEFAULT_NUM_OF_COINS,// 100 coin is default amount.
+    };
+
+    let owner = args.owner;
+
+    let transaction = Transaction {
+        inputs: Vec::new(),
+        peeks: Vec::new(),
+        outputs: vec![(Coin::<0>::new(amount), OuterVerifier::Sr25519Signature(Sr25519Signature {
+            owner_pubkey: owner,
+        })).into()],
+        checker: OuterConstraintChecker::Money(MoneyConstraintChecker::Mint),
+    };
+
+
+    let spawn_hex = hex::encode(transaction.encode());
+    let params = rpc_params![spawn_hex];
+    let _spawn_response: Result<String, _> = client.request("author_submitExtrinsic", params).await;
+
+    let minted_coin_ref = OutputRef {
+        tx_hash: <BlakeTwo256 as Hash>::hash_of(&transaction.encode()),
+        index: 0,
+    };
+    sleep(Duration::from_secs(3));
+
+    let coin_from_storage = get_coin_from_storage(&minted_coin_ref, client).await?;
+    println!("Minted coin from storage = {:?}",coin_from_storage);
+    Ok(()) 
+}
 
 /// Create and send a transaction that spends coins on the network
 pub async fn spend_coins(

--- a/wallet/src/money.rs
+++ b/wallet/src/money.rs
@@ -20,9 +20,6 @@ use tuxedo_core::{
 
 use std::{thread::sleep, time::Duration};
 
-/// The default number of coins to be minted.
-pub const DEFAULT_NUM_OF_COINS: &str = "100";
-
 /// Create and send a transaction that mints the coins on the network
 pub async fn mint_coins(client: &HttpClient, args: MintCoinArgs) -> anyhow::Result<()> {
     log::info!("The args are:: {:?}", args);
@@ -48,10 +45,12 @@ pub async fn mint_coins(client: &HttpClient, args: MintCoinArgs) -> anyhow::Resu
         tx_hash: <BlakeTwo256 as Hash>::hash_of(&transaction.encode()),
         index: 0,
     };
+
     sleep(Duration::from_secs(3));
 
     let coin_from_storage = get_coin_from_storage(&minted_coin_ref, client).await?;
     println!("Minted coin from storage = {:?}", coin_from_storage);
+
     Ok(())
 }
 

--- a/wallet/src/money.rs
+++ b/wallet/src/money.rs
@@ -24,21 +24,21 @@ use std::{thread::sleep, time::Duration};
 pub const DEFAULT_NUM_OF_COINS: &str = "100";
 
 /// Create and send a transaction that mints the coins on the network
-pub async fn mint_coins(
-    client: &HttpClient,
-    args: MintCoinArgs,
-) -> anyhow::Result<()> {
+pub async fn mint_coins(client: &HttpClient, args: MintCoinArgs) -> anyhow::Result<()> {
     log::info!("The args are:: {:?}", args);
 
     let transaction = Transaction {
         inputs: Vec::new(),
         peeks: Vec::new(),
-        outputs: vec![(Coin::<0>::new(args.amount), OuterVerifier::Sr25519Signature(Sr25519Signature {
-            owner_pubkey: args.owner,
-        })).into()],
+        outputs: vec![(
+            Coin::<0>::new(args.amount),
+            OuterVerifier::Sr25519Signature(Sr25519Signature {
+                owner_pubkey: args.owner,
+            }),
+        )
+            .into()],
         checker: OuterConstraintChecker::Money(MoneyConstraintChecker::Mint),
     };
-
 
     let spawn_hex = hex::encode(transaction.encode());
     let params = rpc_params![spawn_hex];
@@ -51,8 +51,8 @@ pub async fn mint_coins(
     sleep(Duration::from_secs(3));
 
     let coin_from_storage = get_coin_from_storage(&minted_coin_ref, client).await?;
-    println!("Minted coin from storage = {:?}",coin_from_storage);
-    Ok(()) 
+    println!("Minted coin from storage = {:?}", coin_from_storage);
+    Ok(())
 }
 
 /// Create and send a transaction that spends coins on the network


### PR DESCRIPTION
mint-coins functionality is added this is w.r.t below issue .

https://github.com/Off-Narrative-Labs/Tuxedo/issues/163

With this functionality, it is possible to mint the coins via wallet. Below is the spec:

1. We can optionally pass the amount and public key of the owner as arguments to mint-coins.

2. If optional arguments are not passed, below are the default values:

a. The amount is 100 coin
b. owner(public key) is 0xd2bf4b844dfefd6772a8843e669f943408966a977e3ae2af1dd78e0f55f4df67 i.e SHAWN_PUB_KEY

<details>
<summary>Below are test results :</summary>

Case 1: mint the coin passing both args amount and owner

$ ./target/release/tuxedo-template-wallet mint-coins --owner 0xa6a765bff24ed7cb5d6ac9875a07fe991d96e017611e0e73d70111fe3124f628 --amount 800 

[2024-01-16T09:17:00Z INFO tuxedo_template_wallet] Number of blocks in the db: 7 
[2024-01-16T09:17:00Z INFO tuxedo_template_wallet] Wallet database synchronized with node to height 59 
Minted coin from storage = (Coin(800), Sr25519Signature(Sr25519Signature { owner_pubkey: 0xa6a765bff24ed7cb5d6ac9875a07fe991d96e017611e0e73d70111fe3124f628 }))

----- Confirm the coins present in the wallet as below --------- 
$ ./target/release/tuxedo-template-wallet show-all-outputs 
[2024-01-16T09:17:08Z INFO tuxedo_template_wallet] Number of blocks in the db: 59 
[2024-01-16T09:17:08Z INFO tuxedo_template_wallet] Wallet database synchronized with node to height 61 
###### Unspent outputs ###########
01cfc92054966f56522745b7ae5e206141e62ba80f8bf4c405e210a63205956c00000000: owner 0xa6a765bff24ed7cb5d6ac9875a07fe991d96e017611e0e73d70111fe3124f628, amount 800 

95362504966abd5ee55223d09e860bb1dd60eba1425b80fb05e1cc3ad66bf7100000000: owner 0xd2bf4b844dfefd6772a8843e669f943408966a977e3ae2af1dd78e0f55f4df67, amount 100

Case 2: mint the coin by passing the amount >1000 

$ ./target/release/tuxedo-template-wallet mint-coins --owner --amount 5000
 [[2024-01-17T07:17:51Z INFO  tuxedo_template_wallet] Number of blocks in the db: 1
[2024-01-17T07:17:51Z INFO  tuxedo_template_wallet] Wallet database synchronized with node to height 8
[2024-01-17T07:17:51Z INFO  tuxedo_template_wallet::money] The args are:: MintCoinArgs { amount: 5000, owner: 0xd2bf4b844dfefd6772a8843e669f943408966a977e3ae2af1dd78e0f55f4df67 }

----- Confirm the coins present in the wallet as below ---------

$ ./target/release/tuxedo-template-wallet show-all-outputs 
[2024-01-16T09:17:45Z INFO tuxedo_template_wallet] Number of blocks in the db: 72 
[2024-01-16T09:17:45Z INFO tuxedo_template_wallet] Wallet database synchronized with node to height 74 

###### Unspent outputs ###########
01cfc92054966f56522745b7ae5e206141e62ba80f8bf4c405e210a63205956c00000000: owner 0xa6a765bff24ed7cb5d6ac9875a07fe991d96e017611e0e73d70111fe3124f628, amount 800 a95362504966abd5ee55223d09e860bb1dd60eba1425b80fb05e1cc3ad66bf7100000000: owner 0xd2bf4b844dfefd6772a8843e669f943408966a977e3ae2af1dd78e0f55f4df67, amount 100 cd268e62e961c8324c7d5e232ad825a932a7273e66cf86d00c476d48a21b0d8600000000: owner 0xd2bf4b844dfefd6772a8843e669f943408966a977e3ae2af1dd78e0f55f4df67, amount 5000

Case 3: Pass the amount but don't pass the owner public key

$ ./target/release/tuxedo-template-wallet mint-coins --amount 120 
[2024-01-16T09:18:07Z INFO tuxedo_template_wallet] Number of blocks in the db: 74 
[2024-01-16T09:18:07Z INFO tuxedo_template_wallet] Wallet database synchronized with node to height 81 
Minted coin from storage = (Coin(120), Sr25519Signature(Sr25519Signature { owner_pubkey: 0xd2bf4b844dfefd6772a8843e669f943408966a977e3ae2af1dd78e0f55f4df67 }))

----- Confirm the coins present in the wallet as below ---------

$ ./target/release/tuxedo-template-wallet show-all-outputs 
[2024-01-16T09:18:13Z INFO tuxedo_template_wallet] Number of blocks in the db: 81 
[2024-01-16T09:18:13Z INFO tuxedo_template_wallet] Wallet database synchronized with node to height 83 
###### Unspent outputs ########### 
01cfc92054966f56522745b7ae5e206141e62ba80f8bf4c405e210a63205956c00000000: owner 0xa6a765bff24ed7cb5d6ac9875a07fe991d96e017611e0e73d70111fe3124f628, amount 800 

a95362504966abd5ee55223d09e860bb1dd60eba1425b80fb05e1cc3ad66bf7100000000: owner 0xd2bf4b844dfefd6772a8843e669f943408966a977e3ae2af1dd78e0f55f4df67, amount 100 

cd268e62e961c8324c7d5e232ad825a932a7273e66cf86d00c476d48a21b0d8600000000: owner 0xd2bf4b844dfefd6772a8843e669f943408966a977e3ae2af1dd78e0f55f4df67, amount 5000

e0a3cb1d522f42f795028ccf67bfaec814a7c0c1e58268b5f19a70252a0ad16e00000000: owner 0xd2bf4b844dfefd6772a8843e669f943408966a977e3ae2af1dd78e0f55f4df67, amount 120

</details>