### PR TITLE
Cleanups after Verifier trait overhaul

### DIFF
--- a/tuxedo-core/aggregator/src/lib.rs
+++ b/tuxedo-core/aggregator/src/lib.rs
@@ -132,7 +132,7 @@ pub fn tuxedo_verifier(_: TokenStream, body: TokenStream) -> TokenStream {
         /// It is a combined redeemer type for the redeemers of each individual verifier.
         ///
         /// This type is accessible downstream as `<OuterVerifier as Verifier>::Redeemer`
-        #[derive(Debug, Decode)]
+        #[derive(Debug, Encode, Decode)]
         #vis enum #redeemer_type {
             #(
                 #variants(<#inner_types as tuxedo_core::Verifier>::Redeemer),

--- a/tuxedo-core/src/executive.rs
+++ b/tuxedo-core/src/executive.rs
@@ -436,7 +436,7 @@ where
             "Entering `inherent_extrinsics`."
         );
 
-        // Extract the complete parent block from the inheret data
+        // Extract the complete parent block from the inherent data
         let parent: B = data
             .get_data(&PARENT_INHERENT_IDENTIFIER)
             .expect("Parent block inherent data should be able to decode.")

--- a/tuxedo-core/src/executive.rs
+++ b/tuxedo-core/src/executive.rs
@@ -88,7 +88,7 @@ where
                         ensure!(
                             input_utxo.verifier.verify(
                                 &stripped_encoded,
-                                0, //IS THIS IT!?!? Is it because block number is not set this early? Why was this not a problem before??
+                                Self::block_height(),
                                 &redeemer
                             ),
                             UtxoError::VerifierError

--- a/tuxedo-core/src/executive.rs
+++ b/tuxedo-core/src/executive.rs
@@ -88,7 +88,7 @@ where
                         ensure!(
                             input_utxo.verifier.verify(
                                 &stripped_encoded,
-                                Self::block_height(),
+                                0, //IS THIS IT!?!? Is it because block number is not set this early? Why was this not a problem before??
                                 &redeemer
                             ),
                             UtxoError::VerifierError

--- a/tuxedo-core/src/executive.rs
+++ b/tuxedo-core/src/executive.rs
@@ -654,6 +654,9 @@ mod tests {
             });
             ext.insert(HEADER_KEY.to_vec(), pre_header.encode());
 
+            // Write a block height.
+            ext.insert(HEIGHT_KEY.to_vec(), pre_header.number.encode());
+
             // Write the noted extrinsics
             ext.insert(EXTRINSIC_KEY.to_vec(), self.noted_extrinsics.encode());
 
@@ -682,7 +685,7 @@ mod tests {
             .execute_with(|| {
                 let input = Input {
                     output_ref,
-                    redeemer: Default::default(),
+                    redeemer: RedemptionStrategy::Redemption(Vec::new()),
                 };
 
                 let tx = TestTransactionBuilder::default()

--- a/tuxedo-core/src/lib.rs
+++ b/tuxedo-core/src/lib.rs
@@ -30,7 +30,11 @@ const LOG_TARGET: &str = "tuxedo-core";
 
 /// A transient storage key that will hold the partial header while a block is being built.
 /// This key is cleared before the end of the block.
-const HEADER_KEY: &[u8] = b"header"; // 686561646572
+const HEADER_KEY: &[u8] = b"header";
+
+/// A storage key that will store the block height during and after execution.
+/// This allows the block number to be available in the runtime even during off-chain api calls.
+const HEIGHT_KEY: &[u8] = b"height";
 
 /// A transient storage key that will hold the list of extrinsics that have been applied so far.
 /// This key is cleared before the end of the block.

--- a/tuxedo-core/src/verifier.rs
+++ b/tuxedo-core/src/verifier.rs
@@ -29,7 +29,7 @@ pub use simple_signature::{Sr25519Signature, P2PKH};
 /// * An redeemer supplied by the user attempting to spend the input.
 pub trait Verifier: Debug + Encode + Decode + Clone {
     /// The type that will be supplied to satisfy the verifier and redeem the UTXO.
-    type Redeemer: Decode;
+    type Redeemer: Debug + Encode + Decode;
 
     /// Main function in the trait. Does the checks to make sure an output can be spent.
     fn verify(&self, simplified_tx: &[u8], block_height: u32, redeemer: &Self::Redeemer) -> bool;

--- a/wallet/src/keystore.rs
+++ b/wallet/src/keystore.rs
@@ -7,7 +7,7 @@ use parity_scale_codec::Encode;
 use sc_keystore::LocalKeystore;
 use sp_core::{
     crypto::Pair as PairT,
-    sr25519::{Pair, Public},
+    sr25519::{Pair, Public, Signature},
     H256,
 };
 use sp_keystore::Keystore;
@@ -39,12 +39,10 @@ pub fn sign_with(
     keystore: &LocalKeystore,
     public: &Public,
     message: &[u8],
-) -> anyhow::Result<Vec<u8>> {
-    let sig = keystore
+) -> anyhow::Result<Signature> {
+    keystore
         .sr25519_sign(KEY_TYPE, public, message)?
-        .ok_or(anyhow!("Key doesn't exist in keystore"))?;
-
-    Ok(sig.encode())
+        .ok_or(anyhow!("Key doesn't exist in keystore"))
 }
 
 /// Insert the private key associated with the given seed into the keystore for later use.

--- a/wallet/src/money.rs
+++ b/wallet/src/money.rs
@@ -4,7 +4,7 @@ use crate::{cli::MintCoinArgs, cli::SpendArgs, rpc::fetch_storage, sync};
 
 use anyhow::anyhow;
 use jsonrpsee::{core::client::ClientT, http_client::HttpClient, rpc_params};
-use parity_scale_codec::{Decode, Encode};
+use parity_scale_codec::Encode;
 use runtime::{
     money::{Coin, MoneyConstraintChecker},
     OuterConstraintChecker, OuterVerifier, OuterVerifierRedeemer,


### PR DESCRIPTION
This PR fixes a few bugs that were introduced with #172.

Specifically, it fixes two bugs:
1. The wallet was not encoding the new strongly typed redeemers properly. We may be able to skip this encoding entirely in a followup now that we have more strongly typed redeemers. For now, I have got the encoding working again.
2. When checking transactions in the pool (an off-chain call), we were calling for the block number which was not available at that time. I've fixed this by persisting the block number in storage between blocks.

I guess it is even more clear that we need the entire wallet script to run in CI now.