### PR TITLE
Fix wallet indexing timestamp

### DIFF
--- a/wallet/src/main.rs
+++ b/wallet/src/main.rs
@@ -76,7 +76,7 @@ async fn main() -> anyhow::Result<()> {
         matches![v,
             OuterVerifier::Sr25519Signature(Sr25519Signature { owner_pubkey })
                 if crate::keystore::has_key(&keystore, owner_pubkey)
-        ] || matches![v, OuterVerifier::UpForGrabs(UpForGrabs)] // used for timestamp
+        ]
     };
 
     if !sled::Db::was_recovered(&db) {

--- a/wallet/src/sync.rs
+++ b/wallet/src/sync.rs
@@ -280,16 +280,13 @@ async fn apply_transaction<F: Fn(&OuterVerifier) -> bool, C: ConstraintChecker>(
     let tx = Transaction::<OuterVerifier, C>::decode(&mut &encoded_extrinsic[..])?;
 
     // Insert all new outputs
-    for (index, output) in tx
-        .outputs
-        .iter()
-        .filter(|o| filter(&o.verifier))
-        .enumerate()
-    {
+    for (index, output) in tx.outputs.iter().enumerate() {
         // For now the wallet only supports simple coins and timestamp
         match output.payload.type_id {
             Coin::<0>::TYPE_ID => {
-                crate::money::apply_transaction(db, tx_hash, index as u32, output)?;
+                if filter(&output.verifier) {
+                    crate::money::apply_transaction(db, tx_hash, index as u32, output)?;
+                }
             }
             Timestamp::TYPE_ID => {
                 crate::timestamp::apply_transaction(db, output)?;


### PR DESCRIPTION
This PR fixes a bug in the wallet that prevented it from properly indexing the timestamp. Previously the timestamp inherent abused the `UpForGrabs` verifier. This verifier was caught by the wallet's output filter, and indexed.

Later in #172 we refactored away from using `UpForGrabs` which silently broke the wallet's timestamp functionality.

This PR changes the wallet to index the timestamp regardless of whether it meets the user's normal output filter.