### PR TITLE
Simple metadata to distinguish parachain template from standalone template

### DIFF
--- a/tuxedo-core/src/lib.rs
+++ b/tuxedo-core/src/lib.rs
@@ -11,6 +11,7 @@ mod executive;
 pub mod constraint_checker;
 pub mod genesis;
 pub mod inherents;
+pub mod metadata;
 pub mod support_macros;
 pub mod traits;
 pub mod types;
@@ -21,6 +22,7 @@ pub use aggregator::{aggregate, tuxedo_constraint_checker, tuxedo_verifier};
 pub use constraint_checker::{ConstraintChecker, SimpleConstraintChecker};
 pub use executive::Executive;
 pub use inherents::{InherentAdapter, InherentHooks};
+pub use metadata::TuxedoMetadata;
 pub use verifier::Verifier;
 
 /// A Tuxedo-specific target for diagnostic node log messages

--- a/tuxedo-core/src/metadata.rs
+++ b/tuxedo-core/src/metadata.rs
@@ -2,7 +2,7 @@
 //! are dealing with a parachain or not.
 
 use parity_scale_codec::{Decode, Encode};
-#[derive(Debug, Encode, Decode)]
+#[derive(Default, Debug, Encode, Decode)]
 pub struct TuxedoMetadata {
     /// Placeholder for the scale info type registry that will hopefully eventually go here.
     _registry: (),
@@ -20,15 +20,5 @@ impl TuxedoMetadata {
 
     pub fn is_parachain(&self) -> bool {
         self.parachain
-    }
-}
-
-#[allow(clippy::derivable_impls)]
-impl Default for TuxedoMetadata {
-    fn default() -> Self {
-        Self {
-            _registry: (),
-            parachain: false,
-        }
     }
 }

--- a/tuxedo-core/src/metadata.rs
+++ b/tuxedo-core/src/metadata.rs
@@ -1,3 +1,8 @@
+//!
+//! 
+
+use parity_scale_codec::{Decode, Encode};
+#[derive(Debug, Encode, Decode)]
 pub struct TuxedoMetadata {
     /// Placeholder for the scale info type registry that will hopefully eventually go here.
     _registry: (),

--- a/tuxedo-core/src/metadata.rs
+++ b/tuxedo-core/src/metadata.rs
@@ -1,0 +1,28 @@
+pub struct TuxedoMetadata {
+    /// Placeholder for the scale info type registry that will hopefully eventually go here.
+    _registry: (),
+    /// Indicator of whether this chain is a parachain or not.
+    parachain: bool,
+}
+
+impl TuxedoMetadata {
+    pub fn new_parachain() -> Self {
+        Self {
+            _registry: (),
+            parachain: true,
+        }
+    }
+
+    pub fn is_parachain(&self) -> bool {
+        self.parachain
+    }
+}
+
+impl Default for TuxedoMetadata {
+    fn default() -> Self {
+        Self {
+            _registry: (),
+            parachain: false,
+        }
+    }
+}

--- a/tuxedo-core/src/metadata.rs
+++ b/tuxedo-core/src/metadata.rs
@@ -1,5 +1,5 @@
 //!
-//! 
+//!
 
 use parity_scale_codec::{Decode, Encode};
 #[derive(Debug, Encode, Decode)]

--- a/tuxedo-core/src/metadata.rs
+++ b/tuxedo-core/src/metadata.rs
@@ -1,5 +1,5 @@
-//!
-//!
+//! A simple type to use as metadata. For now the metadata just communicates whether we
+//! are dealing with a parachain or not.
 
 use parity_scale_codec::{Decode, Encode};
 #[derive(Debug, Encode, Decode)]
@@ -23,6 +23,7 @@ impl TuxedoMetadata {
     }
 }
 
+#[allow(clippy::derivable_impls)]
 impl Default for TuxedoMetadata {
     fn default() -> Self {
         Self {

--- a/tuxedo-parachain-runtime/src/lib.rs
+++ b/tuxedo-parachain-runtime/src/lib.rs
@@ -29,7 +29,7 @@ use tuxedo_core::{
     genesis::TuxedoGenesisConfigBuilder, tuxedo_constraint_checker, types::Block as TuxedoBlock,
     types::Transaction as TuxedoTransaction, InherentAdapter,
 };
-use tuxedo_parachain_core::tuxedo_core;
+use tuxedo_parachain_core::tuxedo_core::{self, TuxedoMetadata};
 
 // We use the same aggregate verifier and opaque types from the inner_runtime.
 // They do not contain anything parachain specific.
@@ -149,10 +149,10 @@ impl_runtime_apis! {
         }
     }
 
-    // Tuxedo does not yet support metadata
+    // Tuxedo metadata is pretty trivial atm
     impl sp_api::Metadata<Block> for Runtime {
         fn metadata() -> OpaqueMetadata {
-            OpaqueMetadata::new(Default::default())
+            OpaqueMetadata::new(TuxedoMetadata::new_parachain().encode())
         }
 
         fn metadata_at_version(_version: u32) -> Option<OpaqueMetadata> {

--- a/tuxedo-template-runtime/src/lib.rs
+++ b/tuxedo-template-runtime/src/lib.rs
@@ -38,6 +38,7 @@ use tuxedo_core::{
     types::Transaction as TuxedoTransaction,
     verifier::{Sr25519Signature, ThresholdMultiSignature, UpForGrabs},
     InherentAdapter,
+    TuxedoMetadata,
 };
 
 pub use amoeba;
@@ -273,10 +274,10 @@ impl_runtime_apis! {
         }
     }
 
-    // Tuxedo does not yet support metadata
+    // Tuxedo metadata is pretty trivial atm
     impl sp_api::Metadata<Block> for Runtime {
         fn metadata() -> OpaqueMetadata {
-            OpaqueMetadata::new(Default::default())
+            OpaqueMetadata::new(TuxedoMetadata::default().encode())
         }
 
         fn metadata_at_version(_version: u32) -> Option<OpaqueMetadata> {

--- a/tuxedo-template-runtime/src/lib.rs
+++ b/tuxedo-template-runtime/src/lib.rs
@@ -37,8 +37,7 @@ use tuxedo_core::{
     tuxedo_constraint_checker, tuxedo_verifier,
     types::Transaction as TuxedoTransaction,
     verifier::{Sr25519Signature, ThresholdMultiSignature, UpForGrabs},
-    InherentAdapter,
-    TuxedoMetadata,
+    InherentAdapter, TuxedoMetadata,
 };
 
 pub use amoeba;

--- a/wallet/src/cli.rs
+++ b/wallet/src/cli.rs
@@ -40,10 +40,6 @@ pub struct Cli {
     /// The keystore will contain the development key Shawn.
     pub dev: bool,
 
-    /// Use the Parachain template encoding instead of the regular node template encoding.
-    #[arg(long, short, verbatim_doc_comment)]
-    pub parachain: bool,
-
     #[command(subcommand)]
     pub command: Option<Command>,
 }


### PR DESCRIPTION
This PR starts exploring the tip of the metadata iceburg.

So far we just encode a single bit which indicates whether the chain is the parachain template or the sovereign template. No other chains are supported.

Seems to be working.